### PR TITLE
Change to BEGIN(\sNEW)? CERTIFICATE REQUEST

### DIFF
--- a/lib/pem.js
+++ b/lib/pem.js
@@ -261,7 +261,7 @@ function getPublicKey(certificate, callback){
 
     var params;
 
-    if(certificate.match(/BEGIN CERTIFICATE REQUEST/)){
+    if(certificate.match(/BEGIN(\sNEW)? CERTIFICATE REQUEST/)){
         params = ["req",
                   "-in",
                   "--TMPFILE--",
@@ -302,7 +302,7 @@ function readCertificateInfo(certificate, callback){
 
     certificate = (certificate || "").toString();
 
-    var type = certificate.match(/BEGIN CERTIFICATE REQUEST/)?"req":"x509",
+    var type = certificate.match(/BEGIN(\sNEW)? CERTIFICATE REQUEST/)?"req":"x509",
         params = [type,
                   "-noout",
                   "-text",
@@ -325,7 +325,7 @@ function readCertificateInfo(certificate, callback){
  */
 function getModulus(certificate, callback){
     var type = "";
-    if ( certificate.match(/BEGIN CERTIFICATE REQUEST/)){
+    if ( certificate.match(/BEGIN(\sNEW)? CERTIFICATE REQUEST/)){
         type="req";
     }else if ( certificate.match(/BEGIN RSA PRIVATE KEY/)){
         type="rsa";


### PR DESCRIPTION
BEGIN(\sNEW)? CERTIFICATE REQUEST is better for some OLD CSR.
