### PR TITLE
fix wildcard certificate creation

### DIFF
--- a/lib/pem.js
+++ b/lib/pem.js
@@ -485,7 +485,7 @@ function generateCSRSubject(options){
 
     Object.keys(csrData).forEach(function(key){
         if(csrData[key]){
-            csrBuilder.push("/" + key + "=" + csrData[key].replace(/[^\w \.\-@]+/g, " ").trim());
+            csrBuilder.push("/" + key + "=" + csrData[key].replace(/[^\w \.\*\-@]+/g, " ").trim());
         }
     });
 

--- a/test/pem.js
+++ b/test/pem.js
@@ -310,5 +310,20 @@ exports["General Tests"] = {
             });
 
         });
+    },
+    "Create and verify wildcard certificate": function(test) {
+        var certInfo = {commonName:"*.node.ee"};
+        pem.createCertificate(Object.create(certInfo), function(error, data){
+            var certificate = (data && data.certificate || "").toString();
+            test.ifError(error);
+            test.ok(fs.readdirSync("./tmp").length == 0);
+
+            pem.readCertificateInfo(certificate, function(error, data){
+                test.ifError(error);
+		test.equal(data.commonName, certInfo.commonName);
+                test.ok(fs.readdirSync("./tmp").length == 0);
+                test.done();
+            });
+        });
     }
 };


### PR DESCRIPTION
certificate created with commonName like *.example.com gets certificate with commonName .example.com
which brings problems to subdomains share one ssl certificate.
