### PR TITLE
getModulus() will now accept Buffers

### DIFF
--- a/lib/pem.js
+++ b/lib/pem.js
@@ -322,6 +322,8 @@ function readCertificateInfo(certificate, callback){
  * @param {Function} callback Callback function with an error object and {modulus}
  */
 function getModulus(certificate, callback){
+    certificate = Buffer.isBuffer(certificate) && certificate.toString() || certificate;
+
     var type = "";
     if ( certificate.match(/BEGIN(\sNEW)? CERTIFICATE REQUEST/)){
         type="req";


### PR DESCRIPTION
If the certificate parameter was a Buffer earlier, it would throw an error and exit. This patch checks if it is a Buffer and converts it into String for compatibility.

By default `fs.readFile`'s encoding is Buffer, so this could help in case the user forgets to properly encode.

All test passed
