### PR TITLE
Iterating over arrays via length instead of enumerating over properties

### DIFF
--- a/lib/pem.js
+++ b/lib/pem.js
@@ -601,7 +601,7 @@ function fetchCertificateData(certData, callback) {
 
 
 function linebrakes(content) {
-    var helper_x, p, subject, type;
+    var helper_x, subject, type;
     helper_x = content.replace(/(C|L|O|OU|ST|CN)=/g, '\n$1=');
     helper_x = preg_match_all('((C|L|O|OU|ST|CN)=[^\n].*)', helper_x);
     for (var p=0; p<helper_x.length; p++) {

--- a/lib/pem.js
+++ b/lib/pem.js
@@ -604,7 +604,7 @@ function linebrakes(content) {
     var helper_x, p, subject, type;
     helper_x = content.replace(/(C|L|O|OU|ST|CN)=/g, '\n$1=');
     helper_x = preg_match_all('((C|L|O|OU|ST|CN)=[^\n].*)', helper_x);
-    for (p in helper_x) {
+    for (var p=0; p<helper_x.length; p++) {
         subject = helper_x[p].trim();
         type = subject.split('=');
         if(type[1].substring(0, 4) !== 'http'){
@@ -632,7 +632,7 @@ function preg_match_all(regex, haystack) {
     var globalMatch = haystack.match(globalRegex);
     var matchArray = [],
         nonGlobalRegex, nonGlobalMatch;
-    for (var i in globalMatch) {
+    for (var i=0; i<globalMatch.length; i++) {
         nonGlobalRegex = new RegExp(regex);
         nonGlobalMatch = globalMatch[i].match(nonGlobalRegex);
         matchArray.push(nonGlobalMatch[1]);


### PR DESCRIPTION
Some module has added .each to the Array class, and everything explodes nicely
