### PR TITLE
Add CA certs to pkcs12 file and read pkcs12 files

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Use `createPrivateKey` for creating private keys
 Where
 
   * **keyBitsize** is an optional size of the key, defaults to 2048 (bit)
-  * **options** is an optional object of the cipher and password (both required for encryption), defaults {cipher:'',password:''} 
+  * **options** is an optional object of the cipher and password (both required for encryption), defaults {cipher:'',password:''}
   (ciphers:["aes128", "aes192", "aes256", "camellia128", "camellia192", "camellia256", "des", "des3", "idea"])
   * **callback** is a callback function with an error object and `{key}`
 
@@ -181,22 +181,34 @@ Where
   * **dhparam** is a PEM encoded DH parameters string
   * **callback** is a callback function with an error object and `{size, prime}`
 
-  
-## Export to PKCS12 keystore
 
-Use `createPkcs12` to export a certificate and the private key to a PKCS12 keystore.
+### Export to a PKCS12 keystore
+
+Use `createPkcs12` to export a certificate, the private key and optionally any signing or intermediate CA certificates to a PKCS12 keystore.
 
 	pem.createPkcs12(clientKey, certificate, p12Password, [options], callback)
-	
+
 Where
 
 * **clientKey** is a PEM encoded private key
 * **certificate** is a PEM encoded certificate
 * **p12Password** is the password of the exported keystore
-* **options** is an optional options object with `cipher` and `clientKeyPassword` (ciphers:["aes128", "aes192", "aes256", "camellia128", "camellia192", "camellia256", "des", "des3", "idea"])
+* **options** is an optional options object with `cipher`, (one of "aes128", "aes192", "aes256", "camellia128", "camellia192", "camellia256", "des", "des3" or "idea"), `clientKeyPassword` and `certFiles` (an array of additional certificates to include - e.g. CA certificates)
 * **callback** is a callback function with an error object and `{pkcs12}` (binary)
 
-## Verify a certificate signing chain
+### Read a PKCS12 keystore
+
+Use `readPkcs12` to read a certificate, private key and CA certificates from a PKCS12 keystore.
+
+	pem.readPkcs12(bufferOrPath, [options], callback)
+
+Where
+
+* **bufferOrPath** is a PKCS12 keystore as a [Buffer](https://nodejs.org/api/buffer.html) or the path to a file
+* **options** is an optional options object with `clientKeyPassword` which will be used to encrypt the stored key and `p12Password` which will be used to open the keystore
+* **callback** is a callback function with an error object and `{key: String, cert: String, ca: Array}`
+
+### Verify a certificate signing chain
 
 Use `verifySigningChain` to assert that a given certificate has a valid signing chain.
 

--- a/lib/pem.js
+++ b/lib/pem.js
@@ -21,8 +21,18 @@ module.exports.getModulus = getModulus;
 module.exports.getModulusFromProtected = getModulusFromProtected;
 module.exports.getDhparamInfo = getDhparamInfo;
 module.exports.createPkcs12 = createPkcs12;
+module.exports.readPkcs12 = readPkcs12;
 module.exports.verifySigningChain = verifySigningChain;
 module.exports.config = config;
+
+var KEY_START = '-----BEGIN PRIVATE KEY-----';
+var KEY_END = '-----END PRIVATE KEY-----';
+var RSA_KEY_START = '-----BEGIN RSA PRIVATE KEY-----';
+var RSA_KEY_END = '-----END RSA PRIVATE KEY-----';
+var ENCRYPTED_KEY_START = '-----BEGIN ENCRYPTED PRIVATE KEY-----';
+var ENCRYPTED_KEY_END = '-----END ENCRYPTED PRIVATE KEY-----';
+var CERT_START = '-----BEGIN CERTIFICATE-----';
+var CERT_END = '-----END CERTIFICATE-----';
 
 // PUBLIC API
 
@@ -596,7 +606,7 @@ function createPkcs12(key, certificate, password, options, callback) {
     if (!callback && typeof options === 'function') {
         callback = options;
         options = {};
-    }    
+    }
 
     var params = ['pkcs12','-export'];
     var cipher = ['aes128', 'aes192', 'aes256', 'camellia128', 'camellia192', 'camellia256', 'des', 'des3', 'idea'];
@@ -613,9 +623,16 @@ function createPkcs12(key, certificate, password, options, callback) {
     params.push( '-in' );
     params.push('--TMPFILE--');
     params.push( '-inkey' );
-    params.push('--TMPFILE--');    
+    params.push('--TMPFILE--');
 
     var tmpfiles = [certificate, key];
+
+    if (options && options.certFiles) {
+      tmpfiles.push(options.certFiles.join(''));
+
+      params.push( '-certfile' );
+      params.push('--TMPFILE--');
+    }
 
     execBinaryOpenSSL(params, tmpfiles, function(error, pkcs12) {
         if (error) {
@@ -625,6 +642,62 @@ function createPkcs12(key, certificate, password, options, callback) {
             pkcs12: pkcs12
         });
     });
+}
+
+function readPkcs12(bufferOrPath, options, callback) {
+  if (!callback && typeof options === 'function') {
+      callback = options;
+      options = {};
+  }
+
+  options.p12Password = options.p12Password || '';
+
+  var tmpfiles = [];
+  var args = ['pkcs12', '-in', bufferOrPath, '-passin', 'pass:' + options.p12Password];
+
+  if (Buffer.isBuffer(bufferOrPath)) {
+    tmpfiles = [bufferOrPath];
+    args[2] = '--TMPFILE--';
+  }
+
+  if (options.clientKeyPassword) {
+    args.push('-passout');
+    args.push('pass:' + options.clientKeyPassword);
+  } else {
+    args.push('-nodes');
+  }
+
+  execBinaryOpenSSL(args, tmpfiles, function (error, stdout) {
+    var keybundle = {};
+
+    if (error && error.message.indexOf('No such file or directory') !== -1) {
+      error.code = 'ENOENT';
+    }
+
+    if (!error) {
+      var certs = readFromString(stdout, CERT_START, CERT_END);
+      keybundle.cert = certs.shift();
+      keybundle.ca = certs;
+      keybundle.key = readFromString(stdout, KEY_START, KEY_END).pop();
+
+      if (keybundle.key) {
+        // convert to RSA key
+        return execOpenSSL(['rsa', '-in', '--TMPFILE--'], 'RSA PRIVATE KEY', [keybundle.key], function (error, key) {
+          keybundle.key = key;
+
+          return callback(error, keybundle);
+        });
+      }
+
+      if (options.clientKeyPassword) {
+        keybundle.key = readFromString(stdout, ENCRYPTED_KEY_START, ENCRYPTED_KEY_END).pop();
+      } else {
+        keybundle.key = readFromString(stdout, RSA_KEY_START, RSA_KEY_END).pop();
+      }
+    }
+
+    return callback(error, keybundle);
+  });
 }
 
 /**
@@ -814,6 +887,37 @@ function generateCSRSubject(options) {
     return csrBuilder.join('');
 }
 
+function readFromString(string, start, end) {
+  if (Buffer.isBuffer(string)) {
+    string = string.toString('utf8');
+  }
+
+  var output = [];
+
+  if (!string) {
+    return output;
+  }
+
+  var offset = string.indexOf(start);
+
+  while (offset !== -1) {
+    string = string.substring(offset);
+
+    var endOffset = string.indexOf(end);
+
+    if (endOffset === -1) {
+      break;
+    }
+
+    endOffset += end.length;
+
+    output.push(string.substring(0, endOffset));
+    offset = string.indexOf(start, endOffset);
+  }
+
+  return output;
+}
+
 /**
  * Generically spawn openSSL, without processing the result
  *
@@ -889,8 +993,8 @@ function spawnWrapper(params, tmpfiles, binary, callback) {
     if (!callback && typeof binary === 'function') {
         callback = binary;
         binary = false;
-    }    
-    
+    }
+
     var files = [];
     var toUnlink = [];
 


### PR DESCRIPTION
This PR adds a `certFiles` option to the option object passed to the `createPkcs12` function in order to include one or more CA certificates in a PKCS12 keystore, and also a `readPkcs12` function to read previously created keystores.

Happy to make any necessary changes.
