### PR TITLE
Allow commas in CSR fields

### DIFF
--- a/lib/pem.js
+++ b/lib/pem.js
@@ -880,7 +880,7 @@ function generateCSRSubject(options) {
 
     Object.keys(csrData).forEach(function(key) {
         if (csrData[key]) {
-            csrBuilder.push('/' + key + '=' + csrData[key].replace(/[^\w \.\*\-@]+/g, ' ').trim());
+            csrBuilder.push('/' + key + '=' + csrData[key].replace(/[^\w \.\*\-\,@]+/g, ' ').trim());
         }
     });
 


### PR DESCRIPTION
For Organizations like `MyOrganization, Inc.`.

Fixes #73
