### PR TITLE
Fix 77 - Only generate altNames config when it is a non-empty array

### DIFF
--- a/lib/pem.js
+++ b/lib/pem.js
@@ -186,7 +186,7 @@ function createCSR(options, callback) {
     var tmpfiles = [options.clientKey];
     var config = null;
 
-    if (options.altNames) {
+    if (options.altNames && Array.isArray(options.altNames) && options.altNames.length) {
         params.push('-extensions');
         params.push('v3_req');
         params.push('-config');


### PR DESCRIPTION
If an empty array is passed to `altNames` when generating a CSR, invalid openssl config is created and the command fails.

Fixes #77 
