### PR TITLE
Adding Option for -CAcreateserial on Create Certificate

### DIFF
--- a/lib/pem.js
+++ b/lib/pem.js
@@ -299,15 +299,17 @@ function createCertificate(options, callback) {
     var tmpfiles = [options.csr];
 
     if (options.serviceCertificate) {
-        if (!options.serial) {
-            return callback(new Error('serial option required for CA signing'));
-        }
+
         params.push('-CA');
         params.push('--TMPFILE--');
         params.push('-CAkey');
         params.push('--TMPFILE--');
-        params.push('-set_serial');
-        params.push('0x' + ('00000000' + options.serial.toString(16)).slice(-8));
+        if (options.serial) {
+          params.push('-set_serial');
+          params.push('0x' + ('00000000' + options.serial.toString(16)).slice(-8));
+        } else {
+          params.push('-CAcreateserial');
+        }
         if(options.serviceKeyPassword){
             params.push('-passin');
             params.push('pass:' + options.serviceKeyPassword);


### PR DESCRIPTION
This PR adds a default to create the serial on the certificate generation rather than passing it in.
