### PR TITLE
Fixing CSR subject generation

### DIFF
--- a/lib/pem.js
+++ b/lib/pem.js
@@ -864,7 +864,7 @@ function generateCSRSubject(options) {
 
     var csrBuilder = Object.keys(csrData).map(function(key) {
         if (csrData[key]) {
-            return '/' + key + '=' + csrData[key].replace(/[^\w \.\*\-\,@]+/g, ' ').trim();
+            return '/' + key + '=' + csrData[key].replace(/[^\w \.\*\-\,@']+/g, ' ').trim();
         }
     });
 


### PR DESCRIPTION
The apostrophe character is wrongly being removed from the subject even
though it is valid in an organization name, thus preventing certificate generation by CA. This fix allows the
apostrophe character.