### PR TITLE
Fix error handling and deprecation warnings

### DIFF
--- a/lib/pem.js
+++ b/lib/pem.js
@@ -72,16 +72,24 @@ function createPrivateKey(keyBitsize, options, callback) {
 
     params.push(keyBitsize);
 
-    execOpenSSL(params, 'RSA PRIVATE KEY', function(error, key) {
-        if(clientKeyPassword) {
-            fs.unlink(clientKeyPassword, function() {});
+    execOpenSSL(params, 'RSA PRIVATE KEY', function(sslErr, key) {
+        function done(err) {
+            if (err) {
+                return callback(err);
+            }
+            callback(null, {
+                key: key
+            });
         }
-        if (error) {
-            return callback(error);
+
+        if (clientKeyPassword) {
+            fs.unlink(clientKeyPassword, function(fsErr) {
+                done(sslErr || fsErr);
+            });
         }
-        return callback(null, {
-            key: key
-        });
+        else {
+            done(sslErr);
+        }
     });
 }
 
@@ -217,20 +225,25 @@ function createCSR(options, callback) {
         params.push('file:' + passwordFilePath);
     }
 
-    execOpenSSL(params, 'CERTIFICATE REQUEST', tmpfiles, function(error, data) {
+    execOpenSSL(params, 'CERTIFICATE REQUEST', tmpfiles, function(sslErr, data) {
+        function done(err) {
+            if (err) {
+                return callback(err);
+            }
+            callback(null, {
+                csr: data,
+                config: config,
+                clientKey: options.clientKey
+            });
+        }
         if (passwordFilePath) {
-            fs.unlink(passwordFilePath);
+            fs.unlink(passwordFilePath, function (fsErr) {
+                done(sslErr || fsErr);
+            });
         }
-        if (error) {
-            return callback(error);
+        else {
+            done(sslErr);
         }
-        var response = {
-            csr: data,
-            config: config,
-            clientKey: options.clientKey
-        };
-        return callback(null, response);
-
     });
 }
 
@@ -1002,7 +1015,9 @@ function spawnWrapper(params, tmpfiles, binary, callback) {
 
     spawnOpenSSL(params, binary, function(err, code, stdout, stderr) {
         files.forEach(function(file) {
-            fs.unlink(file.path);
+            fs.unlink(file.path, function (/*err*/) {
+                // TODO: Don't ignore unlink errors.
+            });
         });
         callback(err, code, stdout, stderr);
     });


### PR DESCRIPTION
This is a follow up to https://github.com/andris9/pem/pull/91, ensuring that errors from fs.unlink() calls get bubbled up correctly. This also ensures all fs.unlink() calls have a callback, which is important to avoid deprecation warnings on Node 7.