### PR TITLE
Generate certificates using only public key

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,7 +11,8 @@ module.exports = function(grunt) {
         },
 
         nodeunit: {
-            all: 'test/pem.js'
+            all: 'test/pem.js',
+            certPublicKey: 'test/cert-from-publickey.js'
         }
     });
 

--- a/lib/pem.js
+++ b/lib/pem.js
@@ -7,13 +7,14 @@ var net = require('net');
 var crypto = require('crypto');
 var which = require('which');
 var osTmpdir = require('os-tmpdir');
+var semver = require('semver');
 var pathOpenSSL;
 var tempDir = process.env.PEMJS_TMPDIR || osTmpdir();
 
 module.exports.createPrivateKey = createPrivateKey;
 module.exports.createDhparam = createDhparam;
 module.exports.createCSR = createCSR;
-module.exports.createCertificate = createCertificate;
+module.exports.createCertificate = _createCertificate;
 module.exports.readCertificateInfo = readCertificateInfo;
 module.exports.getPublicKey = getPublicKey;
 module.exports.getFingerprint = getFingerprint;
@@ -32,6 +33,31 @@ var ENCRYPTED_KEY_START = '-----BEGIN ENCRYPTED PRIVATE KEY-----';
 var ENCRYPTED_KEY_END = '-----END ENCRYPTED PRIVATE KEY-----';
 var CERT_START = '-----BEGIN CERTIFICATE-----';
 var CERT_END = '-----END CERTIFICATE-----';
+
+/**
+ * Check if used OpenSSL version meets required version
+ * 
+ * @param {String} requiredVersion Required OpenSSL version
+ * @param {Function} callback Callback function with an error object and {version, match}
+ */
+function checkOpenSSLVersion(requiredVersion, callback) {
+    var versionRegex = /OpenSSL\s(\d+.\d+.\d+)[a-z]*\s/;
+
+    execBinaryOpenSSL(['version'], function(err, v) {
+        if (err) {
+            callback && callback(err);
+        } else {
+            var match = versionRegex.exec(v.toString());
+
+            if (match) {
+                callback && callback(null, {
+                    version: match[1],
+                    matched: semver.satisfies(match[1], '>=' + requiredVersion)
+                });
+            }
+        }
+    });
+}
 
 // PUBLIC API
 
@@ -247,6 +273,25 @@ function createCSR(options, callback) {
     });
 }
 
+function _createCertificate(options, callback) {
+    if (options.publicKey) {
+        checkOpenSSLVersion('1.0.2', function (err, result) {
+            if (err) {
+                callback(err);
+            } else {
+                if (result.matched) {
+                    createCertificate(options, callback);
+                } else {
+                    var msg = 'publicKey option requires openssl 1.0.2 or newer, you used ' + result.version;
+                    callback(new Error(msg));
+                }
+            }
+        });
+    } else {
+        createCertificate(options, callback);
+    }
+}
+
 /**
  * Creates a certificate based on a CSR. If CSR is not defined, a new one
  * will be generated automatically. For CSR generation all the options values
@@ -258,6 +303,7 @@ function createCSR(options, callback) {
  * @param {Boolean} [options.selfSigned] If set to true and serviceKey is not defined, use clientKey for signing
  * @param {String} [options.hash] Hash function to use (either md5 sha1 or sha256, defaults to sha256)
  * @param {String} [options.csr] CSR for the certificate, if not defined a new one is generated
+ * @param {String} [options.publicKey] Public key for the certificate (requires OpenSSL 1.0.2)
  * @param {Number} [options.days] Certificate expire time in days
  * @param {String} [options.clientKeyPassword] Password of the client key
  * @param {String} [options.extFile] extension config file - without '-extensions v3_req'

--- a/lib/pem.js
+++ b/lib/pem.js
@@ -355,6 +355,12 @@ function createCertificate(options, callback) {
         params.push('pass:' + options.clientKeyPassword);
     }
 
+    if (options.publicKey) {
+        params.push('-force_pubkey');
+        params.push('--TMPFILE--');
+        tmpfiles.push(options.publicKey);
+    }
+
     execOpenSSL(params, 'CERTIFICATE', tmpfiles, function(error, data) {
         if (error) {
             return callback(error);

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "os-tmpdir": "^1.0.1",
+    "semver": "^5.3.0",
     "which": "^1.2.4"
   },
   "devDependencies": {

--- a/test/bin/openssl-1.0.1
+++ b/test/bin/openssl-1.0.1
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "OpenSSL 1.0.1 7 Dec 2016"

--- a/test/cert-from-publickey.js
+++ b/test/cert-from-publickey.js
@@ -1,0 +1,76 @@
+'use strict';
+
+var pem = require('..');
+var fs = require('fs');
+
+
+process.env.PEMJS_TMPDIR = './tmp';
+
+try {
+    fs.mkdirSync('./tmp');
+} catch (e) {}
+
+exports['OpenSSL 1.0.2 Tests'] = {
+    'Fail when required OpenSSL not used': function(test) {
+        pem.config({
+            pathOpenSSL: './test/bin/openssl-1.0.1'
+        });
+
+        pem.createCertificate({
+          publicKey: '123'
+        }, function (error) {
+          test.ok(error && error.message === 'publicKey option requires openssl 1.0.2 or newer, you used 1.0.1');
+          test.done();
+        });
+    },
+    'Create certificate from public key': function(test) {
+        pem.config({
+            pathOpenSSL: process.env.pathOpenSSL || '/usr/bin/openssl'
+        });
+
+        // create a key pair
+        pem.createCertificate(function (error, data) {
+          var cert = (data && data.certificate || '').toString();
+
+          // extract the public key
+          pem.getPublicKey(cert, function (error, data) {
+            var key = (data && data.publicKey || '').toString();
+
+            // create CA key pair
+            pem.createCertificate({
+              selfSigned: true
+            }, function (error, data) {
+
+              // create the test certificate from extracted public key
+              pem.createCertificate({
+                  publicKey: key,
+                  serviceKey: data.serviceKey,
+                  serviceCertificate: data.certificate,
+              }, function(error, data) {
+                  var certificate = (data && data.certificate || '').toString();
+                  test.ifError(error);
+                  test.ok(certificate);
+                  test.ok(certificate.match(/^\n*\-\-\-\-\-BEGIN CERTIFICATE\-\-\-\-\-\n/));
+                  test.ok(certificate.match(/\n\-\-\-\-\-END CERTIFICATE\-\-\-\-\-\n*$/));
+
+                  test.ok((data && data.clientKey) !== (data && data.serviceKey));
+
+                  test.ok(data && data.clientKey);
+                  test.ok(data && data.serviceKey);
+                  test.ok(data && data.csr);
+
+                  // extract the public key from certificate
+                  pem.getPublicKey(certificate, function(error, data) {
+                    var result = (data && data.publicKey || '').toString();
+                    test.ifError(error);
+                    test.ok(result === key);
+                    test.ok(fs.readdirSync('./tmp').length === 0);
+                    test.done();
+                  });
+              });
+            });
+          });
+        });
+
+    }
+};


### PR DESCRIPTION
The current implementation of `pem.createCertificate` allows creation of a certificates when in possession of the CSR. If no CSR is provided the library will generate a new one.

There are cases when you need to create a certificate from a public key but the corresponding private key is not available to the party that issues the certificate.

This PR extends the functionality of `pem.createCertificate` so that a certificate can be created starting with the public key. The implementation leverages the `-force_pubkey` option introduced in OpenSSL [1.0.2](https://www.openssl.org/docs/man1.0.2/apps/x509.html).

The options object passed to `pem.createCertificate(options, callback)` includes a new option:
* __publicKey__

The PR does not contain test for this feature as it requires OpenSSL 1.0.2 and current tests are not opinionated about which version is available in the CI machine. I would need some guidance on how this should be handled.

One approach is to use Docker based test environment so that we have fine grained control over which versions are installed...