### PR TITLE
Handle slproweb.com openssl Binaries outputting ' = ' rather than '='…

### DIFF
--- a/lib/pem.js
+++ b/lib/pem.js
@@ -734,6 +734,10 @@ function verifySigningChain(certificate, ca, callback) {
 
 function fetchCertificateData(certData, callback) {
     certData = (certData || '').toString();
+
+    // slproweb.com Windows openssl binaries output ' = ' rather than '='
+    certData = certData.replace(/ = /g, '=');
+
     var serial, subject, subject2, extra, tmp, issuer, issuer2, certValues = {issuer:{}};
     var validity = {};
     var san;


### PR DESCRIPTION
… to separate subject fields. Fixes #97 