### PR TITLE
Propagate original options from createCSR to createCertificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,46 @@ Where
 * **ca** is a PEM encoded CA certificate string or an array of certificate strings
 * **callback** is a callback function with an error object and a boolean as arguments
 
+### Custom extensions config file
+
+You can specify custom OpenSSL extensions using the `config` or `extFile` options for `createCertificate` (or using `csrConfigFile` with `createCSR`).
+
+`extFile` and `csrConfigFile` should be paths to the extension files. While `config` will generate a temporary file from the supplied file contents.
+
+If you specify `config` then the `v3_req` section of your config file will be used.
+
+The following would be an example of a Certificate Authority extensions file:
+
+    [req]
+    req_extensions = v3_req
+    distinguished_name = req_distinguished_name
+
+    [req_distinguished_name]
+    commonName = Common Name
+    commonName_max = 64
+
+    [v3_req]
+    basicConstraints = critical,CA:TRUE
+
+While the following would specify subjectAltNames in the resulting certificate:
+
+    [req]
+    req_extensions = v3_req
+
+    [ v3_req ]
+    basicConstraints = CA:FALSE
+    keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+    subjectAltName = @alt_names
+
+    [alt_names]
+    DNS.1 = host1.example.com
+    DNS.2 = host2.example.com
+    DNS.3 = host3.example.com
+
+Note that `createCertificate` and `createCSR` supports the `altNames` option which would be easier to use in most cases.
+
+**Warning: If you specify `altNames` the custom extensions file will not be passed to OpenSSL.**
+
 ### Setting openssl location
 
 In some systems the `openssl` executable might not be available by the default name or it is not included in $PATH. In this case you can define the location of the executable yourself as a one time action after you have loaded the pem module:

--- a/lib/pem.js
+++ b/lib/pem.js
@@ -215,6 +215,8 @@ function createCSR(options, callback) {
             'commonName = Common Name',
             'commonName_max = 64',
         ].join('\n'));
+    } else if(options.config) {
+      config = options.config;
     }
 
     var passwordFilePath = null;


### PR DESCRIPTION
`config` is initialised to `null` in `createCSR`, and it never gets pulled back in if `altNames` is not specified.

This results in `createCertificate` not being able to set x509v3 extensions on the resulting certificate. The only way around this is to manually create your own config file and use the `extFile` option.

Liking the `config` option to `createCertificate` and expecting it to work, I've allowed the `config` option passed into `createCSR` to be sent back to `createCertificate` if no `altNames` are specified.

I've also updated `README.md` to include an example of using the the three config options to avoid confusion as to which section is being used from the extensions file.

Future work should probably include greater flexibility over which OpenSSL options can be enabled, to avoid the use of custom files altogether (while still allowing to do that.) This would enable altNames to be specified while still many of the standard x509v3 extensions.

Testing-wise, how would you like to approach this? Some of the tests should presumably already fail, if you are already testing this option (and they weren't failing). All the tests seem to be in one file... shall I fix the relevant test to make it fail when x509v3 isn't sent through or write a new test to make sure it does?