### PR TITLE
Regex support for new format with spaces

### DIFF
--- a/lib/pem.js
+++ b/lib/pem.js
@@ -835,8 +835,8 @@ function fetchCertificateData(certData, callback) {
 
 function linebrakes(content) {
     var helper_x, subject, type;
-    helper_x = content.replace(/(C|L|O|OU|ST|CN|DC)=/g, '\n$1=');
-    helper_x = preg_match_all('((C|L|O|OU|ST|CN|DC)=[^\n].*)', helper_x);
+    helper_x = content.replace(/(C|L|O|OU|ST|CN|DC)\s?=\s?/g, '\n$1=');
+    helper_x = preg_match_all('((C|L|O|OU|ST|CN|DC)\s?=\s?[^\n].*)', helper_x);
     for (var p=0; p<helper_x.length; p++) {
         subject = helper_x[p].trim();
         type = subject.split('=');


### PR DESCRIPTION
OpenSSL 1.1.0e now outputs the certificate info string as so:

" C = GB, ST = England, O = Organisation, OU = Provisioning, CN = CommonName"

This change adds support for the new format.

