### PR TITLE
add 3 fields to certificate parsing

### DIFF
--- a/lib/pem.js
+++ b/lib/pem.js
@@ -830,16 +830,16 @@ function fetchCertificateData(certData, callback) {
         certValues.validity = validity;
     }
 
-    if (( tmp = certData.match(/Signature Algorithm:([^\n]*)\n/)) && tmp.length > 1) {
-        certValues.signatureAlgorithm = tmp[1];
+    if (( tmp = certData.match(/Signature Algorithm: ([^\n]*)\n/)) && tmp.length > 1) {
+        certValues.signatureAlgorithm = tmp[1]|| '';
     }
 
-    if (( tmp = certData.match(/Public Key:([^\n]*)\n/)) && tmp.length > 1) {
-        certValues.publicKeySize = tmp[1].replace(/[()]/g,'');
+    if (( tmp = certData.match(/Public Key: ([^\n]*)\n/)) && tmp.length > 1) {
+        certValues.publicKeySize = (tmp[1]|| '').replace(/[()]/g,'');
     }
 
-    if (( tmp = certData.match(/Public Key Algorithm:([^\n]*)\n/)) && tmp.length > 1) {
-        certValues.publicKeyAlgorithm = tmp[1];
+    if (( tmp = certData.match(/Public Key Algorithm: ([^\n]*)\n/)) && tmp.length > 1) {
+        certValues.publicKeyAlgorithm = tmp[1]|| '';
     }
 
     callback(null, certValues);

--- a/lib/pem.js
+++ b/lib/pem.js
@@ -829,6 +829,19 @@ function fetchCertificateData(certData, callback) {
     if (validity.start && validity.end) {
         certValues.validity = validity;
     }
+
+    if (( tmp = certData.match(/Signature Algorithm:([^\n]*)\n/)) && tmp.length > 1) {
+        certValues.signatureAlgorithm = tmp[1];
+    }
+
+    if (( tmp = certData.match(/Public Key:([^\n]*)\n/)) && tmp.length > 1) {
+        certValues.publicKeySize = tmp[1].replace(/[()]/g,'');
+    }
+
+    if (( tmp = certData.match(/Public Key Algorithm:([^\n]*)\n/)) && tmp.length > 1) {
+        certValues.publicKeyAlgorithm = tmp[1];
+    }
+
     callback(null, certValues);
 }
 

--- a/test/pem.js
+++ b/test/pem.js
@@ -102,7 +102,10 @@ exports['General Tests'] = {
             organizationUnit: 'test',
             commonName: 'www.node.ee',
             emailAddress: 'andris@node.ee',
-            dc: ''
+            dc: '',
+            signatureAlgorithm: 'sha256WithRSAEncryption',
+            publicKeySize: '2048 bit',
+            publicKeyAlgorithm: 'rsaEncryption'
         };
         
         pem.createCSR({ csrConfigFile: './test/fixtures/test.cnf' }, function(error, data) {
@@ -225,7 +228,10 @@ exports['General Tests'] = {
                     organizationUnit: '',
                     commonName: 'localhost',
                     emailAddress: '',
-                    dc: ''
+                    dc: '',
+                    signatureAlgorithm: 'sha256WithRSAEncryption',
+                    publicKeySize: '2048 bit',
+                    publicKeyAlgorithm: 'rsaEncryption'
                 });
                 test.ok(fs.readdirSync('./tmp').length === 0);
                 test.done();
@@ -243,7 +249,10 @@ exports['General Tests'] = {
             organizationUnit: 'test',
             commonName: 'www.node.ee',
             emailAddress: 'andris@node.ee',
-            dc: ''
+            dc: '',
+            signatureAlgorithm: 'sha256WithRSAEncryption',
+            publicKeySize: '2048 bit',
+            publicKeyAlgorithm: 'rsaEncryption'
         };
         pem.createCSR(Object.create(certInfo), function(error, data) {
             var csr = (data && data.csr || '').toString();
@@ -273,6 +282,18 @@ exports['General Tests'] = {
                 }
                 if (data.serial) {
                     delete data.serial;
+                }
+
+                if (data.signatureAlgorithm){
+                    delete data.signatureAlgorithm;
+                }
+
+                if (data.publicKeySize){
+                    delete data.publicKeySize;
+                }
+
+                if (data.publicKeyAlgorithm){
+                    delete data.publicKeyAlgorithm;
                 }
 
                 test.deepEqual(data, {
@@ -318,7 +339,10 @@ exports['General Tests'] = {
             organizationUnit: 'test',
             commonName: 'www.node.ee',
             emailAddress: 'andris@node.ee',
-            dc: ''
+            dc: '',
+            signatureAlgorithm: 'sha256WithRSAEncryption',
+            publicKeySize: '2048 bit',
+            publicKeyAlgorithm: 'rsaEncryption'
         };
         pem.createCertificate(Object.create(certInfo), function(error, data) {
             var certificate = (data && data.certificate || '').toString();

--- a/test/pem.js
+++ b/test/pem.js
@@ -104,7 +104,6 @@ exports['General Tests'] = {
             emailAddress: 'andris@node.ee',
             dc: '',
             signatureAlgorithm: 'sha256WithRSAEncryption',
-            publicKeySize: '2048 bit',
             publicKeyAlgorithm: 'rsaEncryption'
         };
         
@@ -120,6 +119,9 @@ exports['General Tests'] = {
 
             pem.readCertificateInfo(csr, function(error, data) {
                 test.ifError(error);
+                if (data.publicKeySize){
+                    delete data.publicKeySize;
+                }
                 test.deepEqual(data, certInfo);
                 test.ok(fs.readdirSync('./tmp').length === 0);
                 test.done();
@@ -219,6 +221,9 @@ exports['General Tests'] = {
 
             pem.readCertificateInfo(csr, function(error, data) {
                 test.ifError(error);
+                if (data.publicKeySize){
+                    delete data.publicKeySize;
+                }
                 test.deepEqual(data, {
                     issuer : {},
                     country: '',
@@ -230,7 +235,6 @@ exports['General Tests'] = {
                     emailAddress: '',
                     dc: '',
                     signatureAlgorithm: 'sha256WithRSAEncryption',
-                    publicKeySize: '2048 bit',
                     publicKeyAlgorithm: 'rsaEncryption'
                 });
                 test.ok(fs.readdirSync('./tmp').length === 0);
@@ -251,7 +255,6 @@ exports['General Tests'] = {
             emailAddress: 'andris@node.ee',
             dc: '',
             signatureAlgorithm: 'sha256WithRSAEncryption',
-            publicKeySize: '2048 bit',
             publicKeyAlgorithm: 'rsaEncryption'
         };
         pem.createCSR(Object.create(certInfo), function(error, data) {
@@ -261,6 +264,9 @@ exports['General Tests'] = {
 
             pem.readCertificateInfo(csr, function(error, data) {
                 test.ifError(error);
+                if (data.publicKeySize){
+                    delete data.publicKeySize;
+                }
                 test.deepEqual(data, certInfo);
                 test.ok(fs.readdirSync('./tmp').length === 0);
                 test.done();
@@ -341,7 +347,6 @@ exports['General Tests'] = {
             emailAddress: 'andris@node.ee',
             dc: '',
             signatureAlgorithm: 'sha256WithRSAEncryption',
-            publicKeySize: '2048 bit',
             publicKeyAlgorithm: 'rsaEncryption'
         };
         pem.createCertificate(Object.create(certInfo), function(error, data) {
@@ -357,6 +362,9 @@ exports['General Tests'] = {
                 }
                 if (data.serial) {
                     delete data.serial;
+                }
+                if (data.publicKeySize){
+                    delete data.publicKeySize;
                 }
 
                 test.deepEqual(data, certInfo);


### PR DESCRIPTION
Dear Josef
We are happy to find your package that implement all requirements we need to parse and validate SSL certificate in PEM format. It's very clear and convenient.
The only thing we miss here is 3 certificate's fields - signatureAlgorithm, publicKeyAlgorithm and publicKeySize. Please add them to the implementation of fetchCertificateData.

Thanks in advance,
Tatyana Bolshinsky
Senior Software Developer
IBM Cloud Security Team  