### PR TITLE
Support reading array of organizations in a CSR

### DIFF
--- a/lib/pem.js
+++ b/lib/pem.js
@@ -767,8 +767,7 @@ function fetchCertificateData(certData, callback) {
 
         // organization
         tmp = subject2.matchAll(/\sO=([^\n].*)/g);
-        certValues.organization = tmp && tmp.length>1 ? tmp.map(x => x[1]) : tmp[0][1];
-        console.log(tmp);
+        certValues.organization = tmp ? tmp.length>1 ? tmp.map(x => x[1]) : tmp[0][1] : '';
         
         // unit
         tmp = subject2.match(/\sOU=([^\n].*?)[\n]/);

--- a/lib/pem.js
+++ b/lib/pem.js
@@ -764,11 +764,9 @@ function fetchCertificateData(certData, callback) {
         // locality
         tmp = subject2.match(/\sL=([^\n].*?)[\n]/);
         certValues.locality = tmp && tmp[1] || '';
-
         // organization
         tmp = subject2.matchAll(/\sO=([^\n].*)/g);
         certValues.organization = tmp ? tmp.length>1 ? tmp.map(x => x[1]) : tmp[0][1] : '';
-        
         // unit
         tmp = subject2.match(/\sOU=([^\n].*?)[\n]/);
         certValues.organizationUnit = tmp && tmp[1] || '';

--- a/lib/pem.js
+++ b/lib/pem.js
@@ -766,7 +766,7 @@ function fetchCertificateData(certData, callback) {
         certValues.locality = tmp && tmp[1] || '';
         // organization
         tmp = subject2.matchAll(/\sO=([^\n].*)/g);
-        certValues.organization = tmp ? tmp.length>1 ? tmp.map(x => x[1]) : tmp[0][1] : '';
+        certValues.organization = tmp ? tmp.length>1 ? tmp.map(function(x) {return x[1];}) : tmp[0][1] : '';
         // unit
         tmp = subject2.match(/\sOU=([^\n].*?)[\n]/);
         certValues.organizationUnit = tmp && tmp[1] || '';

--- a/lib/pem.js
+++ b/lib/pem.js
@@ -764,9 +764,12 @@ function fetchCertificateData(certData, callback) {
         // locality
         tmp = subject2.match(/\sL=([^\n].*?)[\n]/);
         certValues.locality = tmp && tmp[1] || '';
+
         // organization
-        tmp = subject2.match(/\sO=([^\n].*?)[\n]/);
-        certValues.organization = tmp && tmp[1] || '';
+        tmp = subject2.matchAll(/\sO=([^\n].*)/g);
+        certValues.organization = tmp && tmp.length>1 ? tmp.map(x => x[1]) : tmp[0][1];
+        console.log(tmp);
+        
         // unit
         tmp = subject2.match(/\sOU=([^\n].*?)[\n]/);
         certValues.organizationUnit = tmp && tmp[1] || '';
@@ -845,6 +848,17 @@ function fetchCertificateData(certData, callback) {
     callback(null, certValues);
 }
 
+String.prototype.matchAll = function(regexp) {
+  var matches = [];
+  this.replace(regexp, function() {
+    var arr = ([]).slice.call(arguments, 0);
+    var extras = arr.splice(-2);
+    arr.index = extras[0];
+    arr.input = extras[1];
+    matches.push(arr);
+  });
+  return matches.length ? matches : null;
+};
 
 function linebrakes(content) {
     var helper_x, subject, type;
@@ -901,10 +915,18 @@ function generateCSRSubject(options) {
             emailAddress: options.emailAddress
     };
 
-    var csrBuilder = Object.keys(csrData).map(function(key) {
-        if (csrData[key]) {
-            return '/' + key + '=' + csrData[key].replace(/[^\w \.\*\-\,@']+/g, ' ').trim();
+    var csrBuilder = Object.keys(csrData).map(function (key) {
+      if (csrData[key]) {
+        if (typeof csrData[key] === 'object' && csrData[key].length >= 1) {
+          var tmpStr = '';
+          csrData[key].map(function (o) {
+            tmpStr += '/' + key + '=' + o.replace(/[^\w \.\*\-\,@']+/g, ' ').trim();
+          });
+          return tmpStr;
+        } else {
+          return '/' + key + '=' + csrData[key].replace(/[^\w \.\*\-\,@']+/g, ' ').trim();
         }
+      }
     });
 
     return csrBuilder.join('');

--- a/test/pem.js
+++ b/test/pem.js
@@ -143,7 +143,22 @@ exports['General Tests'] = {
             publicKeySize: '2048 bit'
         };
         
-        pem.createCSR({ csrConfigFile: './test/fixtures/test.cnf' }, function(error, data) {
+        var expectedCertInfo = {
+            issuer : {},
+            country: 'EE',
+            state: 'Harjumaa',
+            locality: 'Tallinn',
+            organization: ['Node.ee', 'Node2.ee'],
+            organizationUnit: 'test',
+            commonName: 'www.node.ee',
+            emailAddress: 'andris@node.ee',
+            dc: '',
+            signatureAlgorithm: 'sha256WithRSAEncryption',
+            publicKeyAlgorithm: 'rsaEncryption',
+            publicKeySize: '2048 bit'
+        };
+        
+        pem.createCSR(certInfo, function(error, data) {
             var csr = (data && data.csr || '').toString();
             test.ifError(error);
             test.ok(csr);
@@ -155,7 +170,7 @@ exports['General Tests'] = {
 
             pem.readCertificateInfo(csr, function(error, data) {
                 test.ifError(error);
-                test.deepEqual(data, certInfo);
+                test.deepEqual(data, expectedCertInfo);
                 test.ok(fs.readdirSync('./tmp').length === 0);
                 test.done();
             });

--- a/test/pem.js
+++ b/test/pem.js
@@ -127,6 +127,41 @@ exports['General Tests'] = {
         });
     },
 
+    'Create CSR with multiple organizations using config file': function(test) {
+        var certInfo = {
+            issuer : {},
+            country: 'EE',
+            state: 'Harjumaa',
+            locality: 'Tallinn',
+            organization: ['Node.ee', 'Node2.ee'],
+            organizationUnit: 'test',
+            commonName: 'www.node.ee',
+            emailAddress: 'andris@node.ee',
+            dc: '',
+            signatureAlgorithm: 'sha256WithRSAEncryption',
+            publicKeyAlgorithm: 'rsaEncryption',
+            publicKeySize: '2048 bit'
+        };
+        
+        pem.createCSR({ csrConfigFile: './test/fixtures/test.cnf' }, function(error, data) {
+            var csr = (data && data.csr || '').toString();
+            test.ifError(error);
+            test.ok(csr);
+            test.ok(csr.match(/^\n*\-\-\-\-\-BEGIN CERTIFICATE REQUEST\-\-\-\-\-\n/));
+            test.ok(csr.match(/\n\-\-\-\-\-END CERTIFICATE REQUEST\-\-\-\-\-\n*$/));
+
+            test.ok(data && data.clientKey);
+            test.ok(fs.readdirSync('./tmp').length === 0);
+
+            pem.readCertificateInfo(csr, function(error, data) {
+                test.ifError(error);
+                test.deepEqual(data, certInfo);
+                test.ok(fs.readdirSync('./tmp').length === 0);
+                test.done();
+            });
+        });
+    },
+
     'Create CSR with own key': function(test) {
         pem.createPrivateKey(function(error, data) {
             var key = (data && data.key || '').toString();


### PR DESCRIPTION
This is an addition to https://github.com/Dexus/pem/pull/124

This allows it to read a CSR that contains multiple organizations. 

Previous Behavior: Was returning the first organization it found and ignored any following organizations

Current Behavior: Returns an array of organizations if there was multiple, otherwise it returns a string of the single organization. This shouldn't require any changes to how existing code uses this module