### PR TITLE
Re-Structuring

### DIFF
--- a/lib/openssl.js
+++ b/lib/openssl.js
@@ -11,13 +11,11 @@ var tempDir = process.env.PEMJS_TMPDIR || osTmpdir()
 
 /**
  * configue this openssl module
- * @param {String} option name
+ * @param {String} option name e.g. pathOpenSSL, openSslVersion //TODO rethink nomenclature
  * @param {*} value value
  */
 function set (option, value) {
-  if (option === 'pathOpenSSL') {
-    settings.pathOpenSSL = value
-  }
+  settings[option] = value
 }
 
 /**

--- a/lib/openssl.js
+++ b/lib/openssl.js
@@ -1,0 +1,230 @@
+var Buffer = require('safe-buffer').Buffer
+var helper = require('./helper.js')
+var spawn = require('child_process').spawn
+var pathlib = require('path')
+var fs = require('fs')
+var osTmpdir = require('os-tmpdir')
+var crypto = require('crypto')
+var which = require('which')
+var settings = {}
+var tempDir = process.env.PEMJS_TMPDIR || osTmpdir()
+
+/**
+ * configue this openssl module
+ * @param {String} option name
+ * @param {*} option vvlue
+ */
+function set (option, value) {
+  if (option === 'pathOpenSSL') {
+    settings.pathOpenSSL = value
+  }
+}
+
+/**
+ * get configuration setting value
+ * @param {String} option name
+ */
+function get (option) {
+  return settings[option] || null
+}
+
+/**
+ * Spawn an openssl command
+ */
+function execOpenSSL (params, searchStr, tmpfiles, callback) {
+  if (!callback && typeof tmpfiles === 'function') {
+    callback = tmpfiles
+    tmpfiles = false
+  }
+
+  spawnWrapper(params, tmpfiles, function (err, code, stdout, stderr) {
+    var start, end
+
+    if (err) {
+      return callback(err)
+    }
+
+    if ((start = stdout.match(new RegExp('\\-+BEGIN ' + searchStr + '\\-+$', 'm')))) {
+      start = start.index
+    } else {
+      start = -1
+    }
+
+    // To get the full EC key with parameters and private key
+    if (searchStr === 'EC PARAMETERS') {
+      searchStr = 'EC PRIVATE KEY'
+    }
+
+    if ((end = stdout.match(new RegExp('^\\-+END ' + searchStr + '\\-+', 'm')))) {
+      end = end.index + (end[0] || '').length
+    } else {
+      end = -1
+    }
+
+    if (start >= 0 && end >= 0) {
+      return callback(null, stdout.substring(start, end))
+    } else {
+      return callback(new Error(searchStr + ' not found from openssl output:\n---stdout---\n' + stdout + '\n---stderr---\n' + stderr + '\ncode: ' + code))
+    }
+  })
+}
+
+/**
+ *  Spawn an openssl command and get binary output
+ **/
+function execBinaryOpenSSL (params, tmpfiles, callback) {
+  if (!callback && typeof tmpfiles === 'function') {
+    callback = tmpfiles
+    tmpfiles = false
+  }
+  spawnWrapper(params, tmpfiles, true, function (err, code, stdout, stderr) {
+    if (err) {
+      return callback(err)
+    }
+    return callback(null, stdout)
+  })
+}
+
+/**
+ * Generically spawn openSSL, without processing the result
+ *
+ * @param {Array}        params   The parameters to pass to openssl
+ * @param {Boolean}      binary   Output of openssl is binary or text
+ * @param {Function}     callback Called with (error, exitCode, stdout, stderr)
+ */
+function spawnOpenSSL (params, binary, callback) {
+  var pathBin = get('pathOpenSSL') || process.env.OPENSSL_BIN || 'openssl'
+
+  testOpenSSLPath(pathBin, function (err) {
+    if (err) {
+      return callback(err)
+    }
+    var openssl = spawn(pathBin, params)
+    var stderr = ''
+
+    var stdout = (binary ? new Buffer(0) : '')
+    openssl.stdout.on('data', function (data) {
+      if (!binary) {
+        stdout += (data || '').toString('binary')
+      } else {
+        stdout = Buffer.concat([stdout, data])
+      }
+    })
+
+    openssl.stderr.on('data', function (data) {
+      stderr += (data || '').toString('binary')
+    })
+    // We need both the return code and access to all of stdout.  Stdout isn't
+    // *really* available until the close event fires; the timing nuance was
+    // making this fail periodically.
+    var needed = 2 // wait for both exit and close.
+    var code = -1
+    var finished = false
+    var done = function (err) {
+      if (finished) {
+        return
+      }
+
+      if (err) {
+        finished = true
+        return callback(err)
+      }
+
+      if (--needed < 1) {
+        finished = true
+        if (code) {
+          if (code === 2 && stderr === '') {
+            return callback(null, code, stdout, stderr)
+          }
+          return callback(new Error('Invalid openssl exit code: ' + code + '\n% openssl ' + params.join(' ') + '\n' + stderr), code)
+        } else {
+          return callback(null, code, stdout, stderr)
+        }
+      }
+    }
+
+    openssl.on('error', done)
+
+    openssl.on('exit', function (ret) {
+      code = ret
+      done()
+    })
+
+    openssl.on('close', function () {
+      stdout = (binary ? stdout : new Buffer(stdout, 'binary').toString('utf-8'))
+      stderr = new Buffer(stderr, 'binary').toString('utf-8')
+      done()
+    })
+  })
+}
+
+function spawnWrapper (params, tmpfiles, binary, callback) {
+  if (!callback && typeof binary === 'function') {
+    callback = binary
+    binary = false
+  }
+
+  var files = []
+  var delTempPWFiles = []
+
+  if (tmpfiles) {
+    tmpfiles = [].concat(tmpfiles || [])
+    params.forEach(function (value, i) {
+      var fpath
+      if (value === '--TMPFILE--') {
+        fpath = pathlib.join(tempDir, crypto.randomBytes(20).toString('hex'))
+        files.push({
+          path: fpath,
+          contents: tmpfiles.shift()
+        })
+        params[i] = fpath
+        delTempPWFiles[delTempPWFiles.length] = fpath
+      }
+    })
+  }
+
+  // TODO: need to refactored
+  files.forEach(function (file) {
+    fs.writeFileSync(file.path, file.contents)
+  })
+
+  spawnOpenSSL(params, binary, function (err, code, stdout, stderr) {
+    helper.helperDeleteTempFiles(delTempPWFiles, function (fsErr) {
+      callback(err || fsErr, code, stdout, stderr)
+    })
+  })
+}
+
+/**
+ * Validates the pathBin for the openssl command.
+ *
+ * @param {String} pathBin The path to OpenSSL Bin
+ * @param {Function} callback Callback function with an error object
+ */
+function testOpenSSLPath (pathBin, callback) {
+  which(pathBin, function (error) {
+    if (error) {
+      return callback(new Error('Could not find openssl on your system on this path: ' + pathBin))
+    }
+
+    callback()
+  })
+}
+
+/**
+* Once PEM is imported, the openSslVersion is set with this function.
+*/
+spawnOpenSSL(['version'], false, function (err, code, stdout, stderr) {
+  var text = String(stdout) + '\n' + String(stderr) + '\n' + String(err)
+  var tmp = text.match(/^LibreSSL/i)
+  set('openSslVersion', (tmp && tmp[0] ? 'LibreSSL' : 'openssl').toUpperCase())
+})
+
+module.exports = {
+  exec: execOpenSSL,
+  execBinary: execBinaryOpenSSL,
+  spawn: spawnOpenSSL,
+  spawnWrapper: spawnWrapper,
+  set: set,
+  get: get
+}

--- a/lib/openssl.js
+++ b/lib/openssl.js
@@ -12,7 +12,7 @@ var tempDir = process.env.PEMJS_TMPDIR || osTmpdir()
 /**
  * configue this openssl module
  * @param {String} option name
- * @param {*} option vvlue
+ * @param {*} value value
  */
 function set (option, value) {
   if (option === 'pathOpenSSL') {
@@ -30,6 +30,10 @@ function get (option) {
 
 /**
  * Spawn an openssl command
+ * @param {Array} params Array of openssl command line parameters
+ * @param {String} searchStr String to use to find data
+ * @param {Array} [tmpfiles] list of temporary files
+ * @param {Function} callback Called with (error, stdout-substring)
  */
 function execOpenSSL (params, searchStr, tmpfiles, callback) {
   if (!callback && typeof tmpfiles === 'function') {
@@ -71,7 +75,10 @@ function execOpenSSL (params, searchStr, tmpfiles, callback) {
 
 /**
  *  Spawn an openssl command and get binary output
- **/
+ * @param {Array} params Array of openssl command line parameters
+ * @param {Array} [tmpfiles] list of temporary files
+ * @param {Function} callback Called with (error, stdout)
+*/
 function execBinaryOpenSSL (params, tmpfiles, callback) {
   if (!callback && typeof tmpfiles === 'function') {
     callback = tmpfiles
@@ -87,7 +94,6 @@ function execBinaryOpenSSL (params, tmpfiles, callback) {
 
 /**
  * Generically spawn openSSL, without processing the result
- *
  * @param {Array}        params   The parameters to pass to openssl
  * @param {Boolean}      binary   Output of openssl is binary or text
  * @param {Function}     callback Called with (error, exitCode, stdout, stderr)
@@ -158,6 +164,13 @@ function spawnOpenSSL (params, binary, callback) {
   })
 }
 
+/**
+ * Wrapper for spawn method
+ * @param {Array} params The parameters to pass to openssl
+ * @param {Array} [tmpfiles] list of temporary files
+ * @param {Boolean} binary Output of openssl is binary or text
+ * @param {Function} callback Called with (error, exitCode, stdout, stderr)
+ */
 function spawnWrapper (params, tmpfiles, binary, callback) {
   if (!callback && typeof binary === 'function') {
     callback = binary
@@ -196,8 +209,7 @@ function spawnWrapper (params, tmpfiles, binary, callback) {
 }
 
 /**
- * Validates the pathBin for the openssl command.
- *
+ * Validates the pathBin for the openssl command
  * @param {String} pathBin The path to OpenSSL Bin
  * @param {Function} callback Callback function with an error object
  */
@@ -211,9 +223,7 @@ function testOpenSSLPath (pathBin, callback) {
   })
 }
 
-/**
-* Once PEM is imported, the openSslVersion is set with this function.
-*/
+/* Once PEM is imported, the openSslVersion is set with this function. */
 spawnOpenSSL(['version'], false, function (err, code, stdout, stderr) {
   var text = String(stdout) + '\n' + String(stderr) + '\n' + String(err)
   var tmp = text.match(/^LibreSSL/i)

--- a/lib/openssl.js
+++ b/lib/openssl.js
@@ -11,7 +11,7 @@ var tempDir = process.env.PEMJS_TMPDIR || osTmpdir()
 
 /**
  * configue this openssl module
- * @param {String} option name e.g. pathOpenSSL, openSslVersion //TODO rethink nomenclature
+ * @param {String} option name e.g. pathOpenSSL, openSslVersion; TODO rethink nomenclature
  * @param {*} value value
  */
 function set (option, value) {

--- a/lib/pem.js
+++ b/lib/pem.js
@@ -1,17 +1,9 @@
 'use strict'
 
 var Buffer = require('safe-buffer').Buffer
-var spawn = require('child_process').spawn
-var pathlib = require('path')
-var fs = require('fs')
 var net = require('net')
-var crypto = require('crypto')
 var helper = require('./helper.js')
-var which = require('which')
-var osTmpdir = require('os-tmpdir')
-var pathOpenSSL
-var openSslVersion
-var tempDir = process.env.PEMJS_TMPDIR || osTmpdir()
+var openssl = require('./openssl.js')
 
 module.exports.createPrivateKey = createPrivateKey
 module.exports.createDhparam = createDhparam
@@ -69,7 +61,7 @@ function createPrivateKey (keyBitsize, options, callback) {
 
   params.push(keyBitsize)
 
-  execOpenSSL(params, 'RSA PRIVATE KEY', function (sslErr, key) {
+  openssl.exec(params, 'RSA PRIVATE KEY', function (sslErr, key) {
     function done (err) {
       if (err) {
         return callback(err)
@@ -104,7 +96,7 @@ function createDhparam (keyBitsize, callback) {
     keyBitsize
   ]
 
-  execOpenSSL(params, 'DH PARAMETERS', function (error, dhparam) {
+  openssl.exec(params, 'DH PARAMETERS', function (error, dhparam) {
     if (error) {
       return callback(error)
     }
@@ -136,7 +128,7 @@ function createEcparam (keyName, callback) {
     'explicit'
   ]
 
-  execOpenSSL(params, 'EC PARAMETERS', function (error, ecparam) {
+  openssl.exec(params, 'EC PARAMETERS', function (error, ecparam) {
     if (error) {
       return callback(error)
     }
@@ -245,7 +237,7 @@ function createCSR (options, callback) {
     helper.helperCreatePasswordFile({'cipher': '', 'password': options.clientKeyPassword, 'passType': 'in'}, params, delTempPWFiles[delTempPWFiles.length])
   }
 
-  execOpenSSL(params, 'CERTIFICATE REQUEST', tmpfiles, function (sslErr, data) {
+  openssl.exec(params, 'CERTIFICATE REQUEST', tmpfiles, function (sslErr, data) {
     function done (err) {
       if (err) {
         return callback(err)
@@ -373,7 +365,7 @@ function createCertificate (options, callback) {
     helper.helperCreatePasswordFile({'cipher': '', 'password': options.clientKeyPassword, 'passType': 'in'}, params, delTempPWFiles[delTempPWFiles.length])
   }
 
-  execOpenSSL(params, 'CERTIFICATE', tmpfiles, function (sslErr, data) {
+  openssl.exec(params, 'CERTIFICATE', tmpfiles, function (sslErr, data) {
     function done (err) {
       if (err) {
         return callback(err)
@@ -431,7 +423,7 @@ function getPublicKey (certificate, callback) {
     ]
   }
 
-  execOpenSSL(params, 'PUBLIC KEY', certificate, function (error, key) {
+  openssl.exec(params, 'PUBLIC KEY', certificate, function (error, key) {
     if (error) {
       return callback(error)
     }
@@ -464,7 +456,7 @@ function readCertificateInfo (certificate, callback) {
     '-in',
     '--TMPFILE--'
   ]
-  spawnWrapper(params, certificate, function (err, code, stdout) {
+  openssl.spawnWrapper(params, certificate, function (err, code, stdout) {
     if (err) {
       return callback(err)
     }
@@ -520,7 +512,7 @@ function getModulus (certificate, password, hash, callback) {
     helper.helperCreatePasswordFile({'cipher': '', 'password': password, 'passType': 'in'}, params, delTempPWFiles[delTempPWFiles.length])
   }
 
-  spawnWrapper(params, certificate, function (sslErr, code, stdout) {
+  openssl.spawnWrapper(params, certificate, function (sslErr, code, stdout) {
     function done (err) {
       if (err) {
         return callback(err)
@@ -556,7 +548,7 @@ function getDhparamInfo (dh, callback) {
     '--TMPFILE--'
   ]
 
-  spawnWrapper(params, dh, function (err, code, stdout) {
+  openssl.spawnWrapper(params, dh, function (err, code, stdout) {
     if (err) {
       return callback(err)
     }
@@ -592,9 +584,9 @@ function getDhparamInfo (dh, callback) {
  * @param {Object} options
  */
 function config (options) {
-  if (options.pathOpenSSL) {
-    pathOpenSSL = options.pathOpenSSL
-  }
+  Object.keys(options).forEach(function (k) {
+    openssl.set(k, options[k])
+  })
 }
 
 /**
@@ -620,7 +612,7 @@ function getFingerprint (certificate, hash, callback) {
     '-' + hash
   ]
 
-  spawnWrapper(params, certificate, function (err, code, stdout) {
+  openssl.spawnWrapper(params, certificate, function (err, code, stdout) {
     if (err) {
       return callback(err)
     }
@@ -676,7 +668,7 @@ function createPkcs12 (key, certificate, password, options, callback) {
     params.push('--TMPFILE--')
   }
 
-  execBinaryOpenSSL(params, tmpfiles, function (sslErr, pkcs12) {
+  openssl.execBinary(params, tmpfiles, function (sslErr, pkcs12) {
     function done (err) {
       if (err) {
         return callback(err)
@@ -718,7 +710,7 @@ function readPkcs12 (bufferOrPath, options, callback) {
     args.push('-nodes')
   }
 
-  execBinaryOpenSSL(args, tmpfiles, function (sslErr, stdout) {
+  openssl.execBinary(args, tmpfiles, function (sslErr, stdout) {
     function done (err) {
       var keybundle = {}
 
@@ -734,7 +726,7 @@ function readPkcs12 (bufferOrPath, options, callback) {
 
         if (keybundle.key) {
         // convert to RSA key
-          return execOpenSSL(['rsa', '-in', '--TMPFILE--'], 'RSA PRIVATE KEY', [keybundle.key], function (err, key) {
+          return openssl.exec(['rsa', '-in', '--TMPFILE--'], 'RSA PRIVATE KEY', [keybundle.key], function (err, key) {
             keybundle.key = key
 
             return callback(err, keybundle)
@@ -783,7 +775,7 @@ function checkCertificate (certificate, passphrase, callback) {
     helper.helperCreatePasswordFile({'cipher': '', 'password': passphrase, 'passType': 'in'}, params, delTempPWFiles[delTempPWFiles.length])
   }
 
-  spawnWrapper(params, certificate, function (sslErr, code, stdout) {
+  openssl.spawnWrapper(params, certificate, function (sslErr, code, stdout) {
     function done (err) {
       if (err) {
         return callback(err)
@@ -829,7 +821,7 @@ function checkPkcs12 (bufferOrPath, passphrase, callback) {
     args[3] = '--TMPFILE--'
   }
 
-  spawnWrapper(args, tmpfiles, function (sslErr, code, stdout, stderr) {
+  openssl.spawnWrapper(args, tmpfiles, function (sslErr, code, stdout, stderr) {
     function done (err) {
       if (err) {
         return callback(err)
@@ -865,7 +857,7 @@ function verifySigningChain (certificate, ca, callback) {
     '--TMPFILE--'
   ]
 
-  spawnWrapper(params, files, function (err, code, stdout) {
+  openssl.spawnWrapper(params, files, function (err, code, stdout) {
     if (err) {
       return callback(err)
     }
@@ -1166,197 +1158,3 @@ function readFromString (string, start, end) {
 
   return output
 }
-
-/**
- * Generically spawn openSSL, without processing the result
- *
- * @param {Array}        params   The parameters to pass to openssl
- * @param {Boolean}      binary   Output of openssl is binary or text
- * @param {Function}     callback Called with (error, exitCode, stdout, stderr)
- */
-function spawnOpenSSL (params, binary, callback) {
-  var pathBin = pathOpenSSL || process.env.OPENSSL_BIN || 'openssl'
-
-  testOpenSSLPath(pathBin, function (err) {
-    if (err) {
-      return callback(err)
-    }
-    var openssl = spawn(pathBin, params)
-    var stderr = ''
-
-    var stdout = (binary ? new Buffer(0) : '')
-    openssl.stdout.on('data', function (data) {
-      if (!binary) {
-        stdout += (data || '').toString('binary')
-      } else {
-        stdout = Buffer.concat([stdout, data])
-      }
-    })
-
-    openssl.stderr.on('data', function (data) {
-      stderr += (data || '').toString('binary')
-    })
-    // We need both the return code and access to all of stdout.  Stdout isn't
-    // *really* available until the close event fires; the timing nuance was
-    // making this fail periodically.
-    var needed = 2 // wait for both exit and close.
-    var code = -1
-    var finished = false
-    var done = function (err) {
-      if (finished) {
-        return
-      }
-
-      if (err) {
-        finished = true
-        return callback(err)
-      }
-
-      if (--needed < 1) {
-        finished = true
-        if (code) {
-          if (code === 2 && stderr === '') {
-            return callback(null, code, stdout, stderr)
-          }
-          return callback(new Error('Invalid openssl exit code: ' + code + '\n% openssl ' + params.join(' ') + '\n' + stderr), code)
-        } else {
-          return callback(null, code, stdout, stderr)
-        }
-      }
-    }
-
-    openssl.on('error', done)
-
-    openssl.on('exit', function (ret) {
-      code = ret
-      done()
-    })
-
-    openssl.on('close', function () {
-      stdout = (binary ? stdout : new Buffer(stdout, 'binary').toString('utf-8'))
-      stderr = new Buffer(stderr, 'binary').toString('utf-8')
-      done()
-    })
-  })
-}
-
-function spawnWrapper (params, tmpfiles, binary, callback) {
-  if (!callback && typeof binary === 'function') {
-    callback = binary
-    binary = false
-  }
-
-  var files = []
-  var delTempPWFiles = []
-
-  if (tmpfiles) {
-    tmpfiles = [].concat(tmpfiles || [])
-    params.forEach(function (value, i) {
-      var fpath
-      if (value === '--TMPFILE--') {
-        fpath = pathlib.join(tempDir, crypto.randomBytes(20).toString('hex'))
-        files.push({
-          path: fpath,
-          contents: tmpfiles.shift()
-        })
-        params[i] = fpath
-        delTempPWFiles[delTempPWFiles.length] = fpath
-      }
-    })
-  }
-
-  // TODO: need to refactored
-  files.forEach(function (file) {
-    fs.writeFileSync(file.path, file.contents)
-  })
-
-  spawnOpenSSL(params, binary, function (err, code, stdout, stderr) {
-    helper.helperDeleteTempFiles(delTempPWFiles, function (fsErr) {
-      callback(err || fsErr, code, stdout, stderr)
-    })
-  })
-}
-
-/**
- * Spawn an openssl command
- */
-function execOpenSSL (params, searchStr, tmpfiles, callback) {
-  if (!callback && typeof tmpfiles === 'function') {
-    callback = tmpfiles
-    tmpfiles = false
-  }
-
-  spawnWrapper(params, tmpfiles, function (err, code, stdout, stderr) {
-    var start, end
-
-    if (err) {
-      return callback(err)
-    }
-
-    if ((start = stdout.match(new RegExp('\\-+BEGIN ' + searchStr + '\\-+$', 'm')))) {
-      start = start.index
-    } else {
-      start = -1
-    }
-
-    // To get the full EC key with parameters and private key
-    if (searchStr === 'EC PARAMETERS') {
-      searchStr = 'EC PRIVATE KEY'
-    }
-
-    if ((end = stdout.match(new RegExp('^\\-+END ' + searchStr + '\\-+', 'm')))) {
-      end = end.index + (end[0] || '').length
-    } else {
-      end = -1
-    }
-
-    if (start >= 0 && end >= 0) {
-      return callback(null, stdout.substring(start, end))
-    } else {
-      return callback(new Error(searchStr + ' not found from openssl output:\n---stdout---\n' + stdout + '\n---stderr---\n' + stderr + '\ncode: ' + code))
-    }
-  })
-}
-
-/**
- *  Spawn an openssl command and get binary output
- **/
-function execBinaryOpenSSL (params, tmpfiles, callback) {
-  if (!callback && typeof tmpfiles === 'function') {
-    callback = tmpfiles
-    tmpfiles = false
-  }
-  spawnWrapper(params, tmpfiles, true, function (err, code, stdout, stderr) {
-    if (err) {
-      return callback(err)
-    }
-    return callback(null, stdout)
-  })
-}
-
-/**
- * Validates the pathBin for the openssl command.
- *
- * @param {String} pathBin The path to OpenSSL Bin
- * @param {Function} callback Callback function with an error object
- */
-function testOpenSSLPath (pathBin, callback) {
-  which(pathBin, function (error) {
-    if (error) {
-      return callback(new Error('Could not find openssl on your system on this path: ' + pathBin))
-    }
-
-    callback()
-  })
-}
-
-/**
-* Once PEM is imported, the openSslVersion is set with this function.
-*/
-spawnOpenSSL(['version'], false, function (err, code, stdout, stderr) {
-  var text = String(stdout) + '\n' + String(stderr) + '\n' + String(err)
-  var tmp = text.match(/^LibreSSL/i)
-  openSslVersion = tmp && tmp[0] ? 'LibreSSL' : 'openssl'
-
-  openSslVersion = openSslVersion.toUpperCase()
-})

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
       "url": "https://www.josef-froehle.de/"
     }
   ],
+  "license": "MIT",
   "name": "pem",
   "description": "Create private keys and certificates with node.js and io.js",
   "version": "0.0.0-development",

--- a/test/pem.spec.js
+++ b/test/pem.spec.js
@@ -15,8 +15,8 @@ if (process.env.TRAVIS === 'true' && process.env.OPENSSL_DIR !== '') {
 }
 
 describe('General Tests', function () {
-  this.timeout(300000)
-  this.slow(2000)
+  this.timeout(300000)// 5 minutes
+  this.slow(2000)// 2 seconds
 
   describe('Requirements', function () {
     it('Create tmp folder', function () {
@@ -54,6 +54,7 @@ describe('General Tests', function () {
       })
     })
     it('Create 2048bit dhparam key', function (done) {
+      this.timeout(600000)// 10 minutes
       pem.createDhparam(2048, function (error, data) {
         hlp.checkError(error)
         hlp.checkDhparam(data, 420, 430)


### PR DESCRIPTION
moved openssl logic in its own separate file. accessible via `openssl.exec()`, `openssl.execBinary()`, `openssl.spawn()` and `openssl.spawnWrapper()` when having `lib/openssl.js` added via require.

Configuration options gone also this way e.g.:
```
openssl.set(key, value);
openssl.get(key);

//e.g.
openssl.set('pathOpenSSL', '.....');
openssl.get('pathOpenSSL');
openssl.get('openSslVersion');
```