### PR TITLE
Docco Integration

### DIFF
--- a/jsdoc.json
+++ b/jsdoc.json
@@ -32,7 +32,7 @@
     "opts": {
       "verbose": true,
       "encoding": "utf8",
-      "destination": "docs/",
+      "destination": "docs/jsdoc",
       "recurse": true,
       "readme": "./README.md",
       "template": "node_modules/docdash"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
   },
   "main": "lib/pem",
   "scripts": {
+    "documentation": "npm run docco --silent && npm run jsdoc --silent",
+    "docco": "docco -l parallel -o docs/docco lib/helper.js lib/openssl.js lib/pem.js",
     "jsdoc": "jsdoc -c jsdoc.json",
     "changelog": "auto-changelog --output HISTORY.md",
     "coverage": "cross-env NODE_ENV=development nyc ./node_modules/.bin/_mocha --opts mocha.opts $(find . -type f -name '*.spec.js'  ! -path './nyc_output/*' ! -path './coverage/*' ! -path './node_modules/*')",
@@ -45,6 +47,7 @@
     "chai": "^4.1.2",
     "cross-env": "^5.0.5",
     "dirty-chai": "^2.0.1",
+    "docco": "^0.7.0",
     "docdash": "^0.4.0",
     "eslint": "^4.8.0",
     "eslint-config-standard": "^10.2.1",


### PR DESCRIPTION
* Path for jsdoc changed to docs/jsdoc
* Path for docco set to docs/docco

`npm run jsdoc`
`npm run docco`
or simply
`npm run documentation` to cover both parts.

Docco is very helpful imo to make very specific and technical source code lines readable when providing inline comments pointing to resources or providing appropriate explanations. That's at least a part we can and should improve on. Currently these inline comments are not often useful or are senseless ;)