### PR TITLE
Docco Integration

### DIFF
--- a/jsdoc.json
+++ b/jsdoc.json
@@ -32,7 +32,7 @@
     "opts": {
       "verbose": true,
       "encoding": "utf8",
-      "destination": "docs/",
+      "destination": "docs/jsdoc",
       "recurse": true,
       "readme": "./README.md",
       "template": "node_modules/docdash"

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -17,9 +17,9 @@ var helper = require('./helper.js')
 // contains all files: key file, cert and ca chain cert files
 
 /**
- * pem convert library interface
+ * pem convert module
  *
- * @interface convert
+ * @module convert
  */
 
 /**
@@ -31,7 +31,7 @@ var helper = require('./helper.js')
  * @param  {String} [type] type of file, use 'rsa' for key file, 'x509' otherwise or leave this parameter out
  * @param  {Function} callback callback method called with error, boolean result
  */
-var PEM2DER = function (pathIN, pathOUT, type, callback) {
+module.exports.PEM2DER = function (pathIN, pathOUT, type, callback) {
   if (!callback && typeof type === 'function') {
     callback = type
     type = 'x509'
@@ -61,7 +61,7 @@ var PEM2DER = function (pathIN, pathOUT, type, callback) {
  * @param  {String} [type] type of file, use 'rsa' for key file, 'x509' otherwise or leave this parameter out
  * @param  {Function} callback callback method called with error, boolean result
  */
-var DER2PEM = function (pathIN, pathOUT, type, callback) {
+module.exports.DER2PEM = function (pathIN, pathOUT, type, callback) {
   if (!callback && typeof type === 'function') {
     callback = type
     type = 'x509'
@@ -90,7 +90,7 @@ var DER2PEM = function (pathIN, pathOUT, type, callback) {
  * @param  {String} pathOUT path of the P7B encoded certificate file to generate
  * @param  {Function} callback callback method called with error, boolean result
  */
-var PEM2P7B = function (pathBundleIN, pathOUT, callback) {
+module.exports.PEM2P7B = function (pathBundleIN, pathOUT, callback) {
   var params = [
     'crl2pkcs7',
     '-nocrl',
@@ -123,7 +123,7 @@ var PEM2P7B = function (pathBundleIN, pathOUT, callback) {
  * @param  {String} pathOUT path of the PEM encoded certificate file to generate
  * @param  {Function} callback callback method called with error, boolean result
  */
-var P7B2PEM = function (pathIN, pathOUT, callback) {
+module.exports.P7B2PEM = function (pathIN, pathOUT, callback) {
   var params = [
     'pkcs7',
     '-print_certs',
@@ -148,7 +148,7 @@ var P7B2PEM = function (pathIN, pathOUT, callback) {
  * @param  {String} password password to set for accessing the PFX file
  * @param  {Function} callback callback method called with error, boolean result
  */
-var PEM2PFX = function (pathBundleIN, pathOUT, password, callback) {
+module.exports.PEM2PFX = function (pathBundleIN, pathOUT, password, callback) {
   var params = [
     'pkcs12',
     '-export',
@@ -192,7 +192,7 @@ var PEM2PFX = function (pathBundleIN, pathOUT, password, callback) {
  * @param  {String} password password to set for accessing the PFX file
  * @param  {Function} callback callback method called with error, boolean result
  */
-var PFX2PEM = function (pathIN, pathOUT, password, callback) {
+module.exports.PFX2PEM = function (pathIN, pathOUT, password, callback) {
   var params = [
     'pkcs12',
     '-in',
@@ -225,7 +225,7 @@ var PFX2PEM = function (pathIN, pathOUT, password, callback) {
  * @param  {String} password password to be set for the PFX file and to be used to access the key file
  * @param  {Function} callback callback method called with error, boolean result
  */
-var P7B2PFX = function (pathBundleIN, pathOUT, password, callback) {
+module.exports.P7B2PFX = function (pathBundleIN, pathOUT, password, callback) {
   var tmpfile = pathBundleIN.cert.replace(/\.[^.]+$/, '.cer')
   var params = [
     'pkcs7',
@@ -275,14 +275,4 @@ var P7B2PFX = function (pathBundleIN, pathOUT, password, callback) {
       })
     }
   })
-}
-
-module.exports = {
-  PEM2DER: PEM2DER,
-  PEM2P7B: PEM2P7B,
-  PEM2PFX: PEM2PFX,
-  DER2PEM: DER2PEM,
-  P7B2PEM: P7B2PEM,
-  P7B2PFX: P7B2PFX,
-  PFX2PEM: PFX2PEM
 }

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -11,15 +11,13 @@ var ciphers = ['aes128', 'aes192', 'aes256', 'camellia128', 'camellia192', 'came
 module.exports.ciphers = ciphers
 
 /**
- * pem helper library interface
+ * pem helper module
  *
- * @interface helper
+ * @module helper
  */
 
 /**
  * Creates a PasswordFile to hide the password form process infos via `ps auxf` etc.
- *
- * @name helper#helperCreatePasswordFile
  * @param {Object} [options] object of cipher, password and passType {cipher:'aes128', password:'xxxx', passType:"in/out/word"}, if the object empty we do nothing
  * @param {Object} params params will be extended with the data that need for the openssl command. IS USED AS POINTER!
  * @param {String} PasswordFile PasswordFile is the filePath that later need to deleted, after the openssl command. IS USED AS POINTER!
@@ -50,8 +48,6 @@ module.exports.helperCreatePasswordFile = function (options, params, PasswordFil
 
 /**
  * Deletes a file or an array of files
- *
- * @name helper#helperDeleteTempFiles
  * @param {Array} files array of files that shoudld be deleted
  * @param {Function} callback Callback function with an error object
  */

--- a/lib/openssl.js
+++ b/lib/openssl.js
@@ -1,6 +1,6 @@
 var Buffer = require('safe-buffer').Buffer
 var helper = require('./helper.js')
-var spawn = require('child_process').spawn
+var cpspawn = require('child_process').spawn
 var pathlib = require('path')
 var fs = require('fs')
 var osTmpdir = require('os-tmpdir')
@@ -10,15 +10,15 @@ var settings = {}
 var tempDir = process.env.PEMJS_TMPDIR || osTmpdir()
 
 /**
- * pem openssl library interface
+ * pem openssl module
  *
- * @interface openssl
+ * @module openssl
  */
 
 /**
  * configue this openssl module
  *
- * @name openssl#set
+ * @static
  * @param {String} option name e.g. pathOpenSSL, openSslVersion; TODO rethink nomenclature
  * @param {*} value value
  */
@@ -29,7 +29,7 @@ function set (option, value) {
 /**
  * get configuration setting value
  *
- * @name openssl#get
+ * @static
  * @param {String} option name
  */
 function get (option) {
@@ -39,13 +39,13 @@ function get (option) {
 /**
  * Spawn an openssl command
  *
- * @name openssl#exec
+ * @static
  * @param {Array} params Array of openssl command line parameters
  * @param {String} searchStr String to use to find data
  * @param {Array} [tmpfiles] list of temporary files
  * @param {Function} callback Called with (error, stdout-substring)
  */
-function execOpenSSL (params, searchStr, tmpfiles, callback) {
+function exec (params, searchStr, tmpfiles, callback) {
   if (!callback && typeof tmpfiles === 'function') {
     callback = tmpfiles
     tmpfiles = false
@@ -86,12 +86,12 @@ function execOpenSSL (params, searchStr, tmpfiles, callback) {
 /**
  *  Spawn an openssl command and get binary output
  *
- * @name openssl#execBinary
+ * @static
  * @param {Array} params Array of openssl command line parameters
  * @param {Array} [tmpfiles] list of temporary files
  * @param {Function} callback Called with (error, stdout)
 */
-function execBinaryOpenSSL (params, tmpfiles, callback) {
+function execBinary (params, tmpfiles, callback) {
   if (!callback && typeof tmpfiles === 'function') {
     callback = tmpfiles
     tmpfiles = false
@@ -107,19 +107,19 @@ function execBinaryOpenSSL (params, tmpfiles, callback) {
 /**
  * Generically spawn openSSL, without processing the result
  *
- * @name openssl#spawn
+ * @static
  * @param {Array}        params   The parameters to pass to openssl
  * @param {Boolean}      binary   Output of openssl is binary or text
  * @param {Function}     callback Called with (error, exitCode, stdout, stderr)
  */
-function spawnOpenSSL (params, binary, callback) {
+function spawn (params, binary, callback) {
   var pathBin = get('pathOpenSSL') || process.env.OPENSSL_BIN || 'openssl'
 
   testOpenSSLPath(pathBin, function (err) {
     if (err) {
       return callback(err)
     }
-    var openssl = spawn(pathBin, params)
+    var openssl = cpspawn(pathBin, params)
     var stderr = ''
 
     var stdout = (binary ? new Buffer(0) : '')
@@ -181,7 +181,7 @@ function spawnOpenSSL (params, binary, callback) {
 /**
  * Wrapper for spawn method
  *
- * @name openssl#spawnWrapper
+ * @static
  * @param {Array} params The parameters to pass to openssl
  * @param {Array} [tmpfiles] list of temporary files
  * @param {Boolean} binary Output of openssl is binary or text
@@ -217,7 +217,7 @@ function spawnWrapper (params, tmpfiles, binary, callback) {
     fs.writeFileSync(file.path, file.contents)
   })
 
-  spawnOpenSSL(params, binary, function (err, code, stdout, stderr) {
+  spawn(params, binary, function (err, code, stdout, stderr) {
     helper.helperDeleteTempFiles(delTempPWFiles, function (fsErr) {
       callback(err || fsErr, code, stdout, stderr)
     })
@@ -227,7 +227,6 @@ function spawnWrapper (params, tmpfiles, binary, callback) {
 /**
  * Validates the pathBin for the openssl command
  *
- * @name openssl#testOpenSSLPath
  * @private
  * @param {String} pathBin The path to OpenSSL Bin
  * @param {Function} callback Callback function with an error object
@@ -237,22 +236,21 @@ function testOpenSSLPath (pathBin, callback) {
     if (error) {
       return callback(new Error('Could not find openssl on your system on this path: ' + pathBin))
     }
-
     callback()
   })
 }
 
 /* Once PEM is imported, the openSslVersion is set with this function. */
-spawnOpenSSL(['version'], false, function (err, code, stdout, stderr) {
+spawn(['version'], false, function (err, code, stdout, stderr) {
   var text = String(stdout) + '\n' + String(stderr) + '\n' + String(err)
   var tmp = text.match(/^LibreSSL/i)
   set('openSslVersion', (tmp && tmp[0] ? 'LibreSSL' : 'openssl').toUpperCase())
 })
 
 module.exports = {
-  exec: execOpenSSL,
-  execBinary: execBinaryOpenSSL,
-  spawn: spawnOpenSSL,
+  exec: exec,
+  execBinary: execBinary,
+  spawn: spawn,
   spawnWrapper: spawnWrapper,
   set: set,
   get: get

--- a/lib/pem.js
+++ b/lib/pem.js
@@ -1,5 +1,11 @@
 'use strict'
 
+/**
+ * pem module
+ *
+ * @module pem
+ */
+
 var Buffer = require('safe-buffer').Buffer
 var net = require('net')
 var helper = require('./helper.js')
@@ -21,6 +27,10 @@ module.exports.verifySigningChain = verifySigningChain
 module.exports.checkCertificate = checkCertificate
 module.exports.checkPkcs12 = checkPkcs12
 module.exports.config = config
+/**
+ * quick access the convert module
+ * @type {module:convert}
+ */
 module.exports.convert = require('./convert.js')
 
 var KEY_START = '-----BEGIN PRIVATE KEY-----'
@@ -33,15 +43,9 @@ var CERT_START = '-----BEGIN CERTIFICATE-----'
 var CERT_END = '-----END CERTIFICATE-----'
 
 /**
- * pem public library interface
- *
- * @interface pem
- */
-
-/**
  * Creates a private key
  *
- * @name pem#createPrivateKey
+ * @static
  * @param {Number} [keyBitsize=2048] Size of the key, defaults to 2048bit
  * @param {Object} [options] object of cipher and password {cipher:'aes128',password:'xxx'}, defaults empty object
  * @param {Function} callback Callback function with an error object and {key}
@@ -85,7 +89,7 @@ function createPrivateKey (keyBitsize, options, callback) {
 /**
  * Creates a dhparam key
  *
- * @name pem#createDhparam
+ * @static
  * @param {Number} [keyBitsize=512] Size of the key, defaults to 512bit
  * @param {Function} callback Callback function with an error object and {dhparam}
  */
@@ -115,8 +119,7 @@ function createDhparam (keyBitsize, callback) {
 
 /**
  * Creates a ecparam key
- *
- * @name pem#createEcparam
+ * @static
  * @param {String} [keyName=secp256k1] Name of the key, defaults to secp256k1
  * @param {Function} callback Callback function with an error object and {ecparam}
  */
@@ -150,8 +153,7 @@ function createEcparam (keyName, callback) {
  * Creates a Certificate Signing Request
  * If client key is undefined, a new key is created automatically. The used key is included
  * in the callback return as clientKey
- *
- * @name pem#createCSR
+ * @static
  * @param {Object} [options] Optional options object
  * @param {String} [options.clientKey] Optional client key to use
  * @param {Number} [options.keyBitsize] If clientKey is undefined, bit size to use for generating a new key (defaults to 2048)
@@ -266,8 +268,7 @@ function createCSR (options, callback) {
  * Creates a certificate based on a CSR. If CSR is not defined, a new one
  * will be generated automatically. For CSR generation all the options values
  * can be used as with createCSR.
- *
- * @name pem#createCertificate
+ * @static
  * @param {Object} [options] Optional options object
  * @param {String} [options.serviceKey] Private key for signing the certificate, if not defined a new one is generated
  * @param {String} [options.serviceKeyPassword] Password of the service key
@@ -396,8 +397,7 @@ function createCertificate (options, callback) {
 
 /**
  * Exports a public key from a private key, CSR or certificate
- *
- * @name pem#getPublicKey
+ * @static
  * @param {String} certificate PEM encoded private key, CSR or certificate
  * @param {Function} callback Callback function with an error object and {publicKey}
  */
@@ -445,8 +445,7 @@ function getPublicKey (certificate, callback) {
 
 /**
  * Reads subject data from a certificate or a CSR
- *
- * @name pem#readCertificateInfo
+ * @static
  * @param {String} certificate PEM encoded CSR or certificate
  * @param {Function} callback Callback function with an error object and {country, state, locality, organization, organizationUnit, commonName, emailAddress}
  */
@@ -477,8 +476,7 @@ function readCertificateInfo (certificate, callback) {
 
 /**
  * get the modulus from a certificate, a CSR or a private key
- *
- * @name pem#getModulus
+ * @static
  * @param {String} certificate PEM encoded, CSR PEM encoded, or private key
  * @param {String} [password] password for the certificate
  * @param {String} [hash] hash function to use (up to now `md5` supported) (default: none)
@@ -546,8 +544,7 @@ function getModulus (certificate, password, hash, callback) {
 
 /**
  * get the size and prime of DH parameters
- *
- * @name pem#getDhparamInfo
+ * @static
  * @param {String} DH parameters PEM encoded
  * @param {Function} callback Callback function with an error object and {size, prime}
  */
@@ -594,8 +591,7 @@ function getDhparamInfo (dh, callback) {
 
 /**
  * config the pem module
- *
- * @name pem#config
+ * @static
  * @param {Object} options
  */
 function config (options) {
@@ -606,8 +602,7 @@ function config (options) {
 
 /**
  * Gets the fingerprint for a certificate
- *
- * @name pem#getFingerprint
+ * @static
  * @param {String} PEM encoded certificate
  * @param {String} [hash] hash function to use (either `md5`, `sha1` or `sha256`, defaults to `sha1`)
  * @param {Function} callback Callback function with an error object and {fingerprint}
@@ -645,8 +640,7 @@ function getFingerprint (certificate, hash, callback) {
 
 /**
  * Export private key and certificate to a PKCS12 keystore
- *
- * @name pem#createPkcs12
+ * @static
  * @param {String} PEM encoded private key
  * @param {String} PEM encoded certificate
  * @param {String} Password of the result PKCS12 file
@@ -702,8 +696,7 @@ function createPkcs12 (key, certificate, password, options, callback) {
 
 /**
  * read sslcert data from Pkcs12 file. Results are provided in callback response in object notation ({cert: .., ca:..., key:...})
- *
- * @name pem#readPkcs12
+ * @static
  * @param  {Buffer|String}   bufferOrPath Buffer or path to file
  * @param  {Object}   [options]      openssl options
  * @param  {Function} callback     Called with error object and sslcert bundle object
@@ -775,8 +768,7 @@ function readPkcs12 (bufferOrPath, options, callback) {
 
 /**
  * Check a certificate
- *
- * @name pem#checkCertificate
+ * @static
  * @param {String} PEM encoded certificate
  * @param {String} [passphrase] password for the certificate
  * @param {Function} callback Callback function with an error object and a boolean valid
@@ -827,8 +819,7 @@ function checkCertificate (certificate, passphrase, callback) {
 
 /**
  * check a PKCS#12 file (.pfx or.p12)
- *
- * @name pem#checkPkcs12
+ * @static
  * @param {Buffer|String} bufferOrPath PKCS#12 certificate
  * @param {String} [passphrase] optional passphrase which will be used to open the keystore
  * @param {Function} callback Callback function with an error object and a boolean valid
@@ -865,8 +856,7 @@ function checkPkcs12 (bufferOrPath, passphrase, callback) {
 
 /**
  * Verifies the signing chain of the passed certificate
- *
- * @name pem#verifySigningChain
+ * @static
  * @param {String} PEM encoded certificate
  * @param {Array} List of CA certificates
  * @param {Function} callback Callback function with an error object and a boolean valid
@@ -897,7 +887,6 @@ function verifySigningChain (certificate, ca, callback) {
 }
 
 // HELPER FUNCTIONS
-
 function fetchCertificateData (certData, callback) {
   certData = (certData || '').toString()
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
   },
   "main": "lib/pem",
   "scripts": {
+    "documentation": "npm run docco --silent && npm run jsdoc --silent",
+    "docco": "docco -l parallel -o docs/docco lib/helper.js lib/openssl.js lib/pem.js",
     "jsdoc": "jsdoc -c jsdoc.json",
     "changelog": "auto-changelog --output HISTORY.md",
     "coverage": "cross-env NODE_ENV=development nyc ./node_modules/.bin/_mocha --opts mocha.opts $(find . -type f -name '*.spec.js'  ! -path './nyc_output/*' ! -path './coverage/*' ! -path './node_modules/*')",
@@ -45,6 +47,7 @@
     "chai": "^4.1.2",
     "cross-env": "^5.0.5",
     "dirty-chai": "^2.0.1",
+    "docco": "^0.7.0",
     "docdash": "^0.4.0",
     "eslint": "^4.8.0",
     "eslint-config-standard": "^10.2.1",


### PR DESCRIPTION
* Path for jsdoc changed to docs/jsdoc
* Path for docco set to docs/docco
* reviewed jsdoc comments and minor source code review to fit jsdoc generator needs

`npm run jsdoc`
`npm run docco`
or simply
`npm run documentation` to cover both parts.

Docco is very helpful imo to make very specific and technical source code lines readable when providing inline comments pointing to resources or providing appropriate explanations. That's at least a part we can and should improve on. Currently these inline comments are not often useful or are senseless ;)