### PR TITLE
readCertificateInfo reports email addresses in subjectAltName field

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Use `readCertificateInfo` for reading subject data from a certificate or a CSR
 Where
 
   * **certificate** is a PEM encoded CSR or a certificate
-  * **callback** is a callback function with an error object and `{serial, country, state, locality, organization, organizationUnit, commonName, emailAddress, validity{start, end}, san{dns, ip}?, issuer{country, state, locality, organization, organizationUnit}, signatureAlgorithm, publicKeyAlgorithm, publicKeySize }`
+  * **callback** is a callback function with an error object and `{serial, country, state, locality, organization, organizationUnit, commonName, emailAddress, validity{start, end}, san{dns, ip, email}?, issuer{country, state, locality, organization, organizationUnit}, signatureAlgorithm, publicKeyAlgorithm, publicKeySize }`
 
 ? *san* is only present if the CSR or certificate has SAN entries.
 

--- a/lib/pem.js
+++ b/lib/pem.js
@@ -1084,6 +1084,10 @@ function fetchCertificateData (certData, callback) {
     // IP-Addresses IPv4 & IPv6
     tmp = pregMatchAll('IP Address:([^,\\r\\n].*?)[,\\r\\n\\s]', san)
     certValues.san.ip = tmp || ''
+
+    // Email Addresses
+    tmp = pregMatchAll('email:([^,\\r\\n].*?)[,\\r\\n\\s]', san)
+    certValues.san.email = tmp || ''
   }
 
   // Validity


### PR DESCRIPTION
A certificate's subjectAltName can include an email address in addition to IP addresses and DNS names.

This PR extends the certificate parsing to recognize any email addresses if present.

For supporting info, see the [OpenSSL documentation](https://www.openssl.org/docs/manmaster/man5/x509v3_config.html#Subject-Alternative-Name) or the [relevant RFC](https://tools.ietf.org/html/rfc5280#section-4.2.1.6).

