### PR TITLE
Ensure synchronous tmpfile writes, deletes

### DIFF
--- a/lib/openssl.js
+++ b/lib/openssl.js
@@ -198,24 +198,25 @@ function spawnWrapper (params, tmpfiles, binary, callback) {
 
   if (tmpfiles) {
     tmpfiles = [].concat(tmpfiles)
-    params.forEach(function (value, i) {
-      var fpath
-      if (value === '--TMPFILE--') {
+    var fpath, i
+    for (i = 0; i < params.length; i++) {
+      if (params[i] === '--TMPFILE--') {
         fpath = pathlib.join(tempDir, crypto.randomBytes(20).toString('hex'))
         files.push({
           path: fpath,
           contents: tmpfiles.shift()
         })
         params[i] = fpath
-        delTempPWFiles[delTempPWFiles.length] = fpath
+        delTempPWFiles.push(fpath)
       }
-    })
+    }
   }
 
-  // TODO: need to refactored
-  files.forEach(function (file) {
+  var file
+  for (i = 0; i < files.length; i++) {
+    file = files[i]
     fs.writeFileSync(file.path, file.contents)
-  })
+  }
 
   spawn(params, binary, function (err, code, stdout, stderr) {
     helper.deleteTempFiles(delTempPWFiles, function (fsErr) {


### PR DESCRIPTION
Encountered the following error intermittently when programatically getting public keys from certificates:
```
Invalid openssl exit code: 1 
% openssl x509 -in --TMPFILE-- -pubkey -noout 
Error opening Certificate --TMPFILE-- 
140660708865888:error:02001002:system library:fopen:No such file or directory:bss_file.c:398:fopen('--TMPFILE--','r') 
140660708865888:error:20074002:BIO routines:FILE_CTRL:system lib:bss_file.c:400:unable to load certificate
```
Because it seemed like a timing issue, I forked the repo and replaced these `forEach` loops with synchronous `for` loops. The fork has been running error-free for me for over 6 months now.