### PR TITLE
Added support to specify the parameter encoding of an ecparam key

### DIFF
--- a/lib/pem.js
+++ b/lib/pem.js
@@ -122,20 +122,24 @@ function createDhparam (keyBitsize, callback) {
  * @static
  * @param {String} [keyName=secp256k1] Name of the key, defaults to secp256k1
  * @param {String} [paramEnc=explicit] Encoding of the elliptic curve parameters, defaults to explicit
+ * @param {Boolean} [noOut=false] This option inhibits the output of the encoded version of the parameters.
  * @param {Function} callback Callback function with an error object and {ecparam}
  */
-function createEcparam (keyName, paramEnc, callback) {
-  if (!callback && !paramEnc && typeof keyName === 'function') {
+function createEcparam (keyName, paramEnc, noOut, callback) {
+  if (!callback && typeof noOut === 'undefined' && !paramEnc && typeof keyName === 'function') {
     callback = keyName
     keyName = undefined
-    paramEnc = undefined
-  } else if (!callback && keyName && typeof paramEnc === 'function') {
+  } else if (!callback && typeof noOut === 'undefined' && keyName && typeof paramEnc === 'function') {
     callback = paramEnc
     paramEnc = undefined
+  } else if (!callback && typeof noOut === 'function' && keyName && paramEnc) {
+    callback = noOut
+    noOut = undefined
   }
 
   keyName = keyName || 'secp256k1'
   paramEnc = paramEnc || 'explicit'
+  noOut = noOut || false
 
   var params = ['ecparam',
     '-name',
@@ -145,7 +149,13 @@ function createEcparam (keyName, paramEnc, callback) {
     paramEnc
   ]
 
-  openssl.exec(params, 'EC PARAMETERS', function (error, ecparam) {
+  var searchString = 'EC PARAMETERS'
+  if (noOut) {
+    params.push('-noout')
+    searchString = 'EC PRIVATE KEY'
+  }
+
+  openssl.exec(params, searchString, function (error, ecparam) {
     if (error) {
       return callback(error)
     }

--- a/lib/pem.js
+++ b/lib/pem.js
@@ -121,22 +121,28 @@ function createDhparam (keyBitsize, callback) {
  * Creates a ecparam key
  * @static
  * @param {String} [keyName=secp256k1] Name of the key, defaults to secp256k1
+ * @param {String} [paramEnc=explicit] Encoding of the elliptic curve parameters, defaults to explicit
  * @param {Function} callback Callback function with an error object and {ecparam}
  */
-function createEcparam (keyName, callback) {
-  if (!callback && typeof keyName === 'function') {
+function createEcparam (keyName, paramEnc, callback) {
+  if (!callback && !paramEnc && typeof keyName === 'function') {
     callback = keyName
     keyName = undefined
+    paramEnc = undefined
+  } else if (!callback && keyName && typeof paramEnc === 'function') {
+    callback = paramEnc
+    paramEnc = undefined
   }
 
   keyName = keyName || 'secp256k1'
+  paramEnc = paramEnc || 'explicit'
 
   var params = ['ecparam',
     '-name',
     keyName,
     '-genkey',
     '-param_enc',
-    'explicit'
+    paramEnc
   ]
 
   openssl.exec(params, 'EC PARAMETERS', function (error, ecparam) {

--- a/test/pem.helper.js
+++ b/test/pem.helper.js
@@ -38,6 +38,15 @@ function checkEcparam (data, min, max) {
   expect(matchup[0].trim().length).to.be.within(min + 1, max - 1)
 }
 
+function checkEcparamNoOut (data, min, max) {
+  expect(data).to.be.an('object').that.has.property('ecparam')
+  expect(data.ecparam).to.be.a('string')
+  expect(/^\r?\n*-----BEGIN EC PRIVATE KEY-----\r?\n/.test(data.ecparam)).to.be.true()
+  expect(/\r?\n-----END EC PRIVATE KEY-----\r?\n*$/.test(data.ecparam)).to.be.true()
+  var matchup = /-----BEGIN EC PRIVATE KEY-----[\s\S]+-----END EC PRIVATE KEY-----/.exec(data.ecparam)
+  expect(matchup[0].trim().length).to.be.within(min + 1, max - 1)
+}
+
 function checkDhparam (data, min, max) {
   expect(data).to.be.an('object').that.has.property('dhparam')
   expect(data.dhparam).to.be.a('string')
@@ -112,6 +121,7 @@ module.exports = {
   checkError: checkError,
   checkDhparam: checkDhparam,
   checkEcparam: checkEcparam,
+  checkEcparamNoOut: checkEcparamNoOut,
   checkPrivateKey: checkPrivateKey,
   checkCSR: checkCSR,
   checkCertificate: checkCertificate,

--- a/test/pem.spec.js
+++ b/test/pem.spec.js
@@ -83,6 +83,14 @@ describe('General Tests', function () {
         done()
       })
     })
+    it('Create prime256v1 ecparam key with named_curve param encoding', function (done) {
+      pem.createEcparam('prime256v1', 'named_curve', function (error, data) {
+        hlp.checkError(error)
+        hlp.checkEcparam(data, 200, 430)
+        hlp.checkTmpEmpty()
+        done()
+      })
+    })
   })
 
   describe('#.createPrivateKey tests', function () {

--- a/test/pem.spec.js
+++ b/test/pem.spec.js
@@ -91,6 +91,22 @@ describe('General Tests', function () {
         done()
       })
     })
+    it('Create prime256v1 ecparam key with noOut set to true', function (done) {
+      pem.createEcparam('prime256v1', 'named_curve', true, function (error, data) {
+        hlp.checkError(error)
+        hlp.checkEcparamNoOut(data, 200, 430)
+        hlp.checkTmpEmpty()
+        done()
+      })
+    })
+    it('Create prime256v1 ecparam key with noOut set to false', function (done) {
+      pem.createEcparam('prime256v1', 'named_curve', false, function (error, data) {
+        hlp.checkError(error)
+        hlp.checkEcparam(data, 200, 430)
+        hlp.checkTmpEmpty()
+        done()
+      })
+    })
   })
 
   describe('#.createPrivateKey tests', function () {


### PR DESCRIPTION
The current implementation of the `createEcParam` function gives no option to specify the encoding for the elliptic curve parameters.

Since that I need ecparams with the named_curve encoding, I added the option to the `createEcParam` function. If the function is called with two parameters it will behave like before my change. 

Added also a test for calling the function with 3 parameters.

Update: also added option to specify `-noout` flag

Thanks!
Chris