### PR TITLE
Fix broken public key detection from PKCS#8 formatted private keys

### DIFF
--- a/lib/pem.js
+++ b/lib/pem.js
@@ -446,7 +446,7 @@ function getPublicKey (certificate, callback) {
       '-pubkey',
       '-noout'
     ]
-  } else if (certificate.match(/BEGIN RSA PRIVATE KEY/)) {
+  } else if (certificate.match(/BEGIN RSA PRIVATE KEY/) || certificate.match(/BEGIN PRIVATE KEY/)) {
     params = ['rsa',
       '-in',
       '--TMPFILE--',


### PR DESCRIPTION
Currently `getPublicKey` does not work with PKCS#8 formatted private keys (`--BEGIN PRIVATE KEY--`), this PR fixes it