### PR TITLE
Fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ pem.config({
 // do something with the pem module
 ```
 
-### Specialthanks to
+### Special thanks to
 
 - Andris Reinman (@andris9) - Initiator of pem
 


### PR DESCRIPTION
Added missing space between the words **_special_** &  **_thanks_**.

![Screenshot 2020-10-05 at 4 18 35 PM](https://user-images.githubusercontent.com/20594326/95070901-72234d80-0726-11eb-8f21-17717379f509.png)
