### PR TITLE
Verify signing chain fix

### DIFF
--- a/lib/pem.js
+++ b/lib/pem.js
@@ -979,7 +979,7 @@ function verifySigningChain (certificate, ca, callback) {
       return callback(err)
     }
 
-    callback(null, stdout.trim().slice(-2) === 'OK')
+    callback(null, stdout.trim().slice(-4) === ': OK')
   })
 }
 

--- a/lib/pem.js
+++ b/lib/pem.js
@@ -933,8 +933,10 @@ function checkPkcs12 (bufferOrPath, passphrase, callback) {
 /**
  * Verifies the signing chain of the passed certificate
  * @static
- * @param {String|Array} PEM encoded certificate include intermediate certificates
- * @param {String|Array} [List] of CA certificates
+ * @param {String|Array} certificate PEM encoded certificate include intermediate certificates
+ * The correct order of trust chain must be preserved and should start with Leaf
+ * certificate. Example array: [Leaf, Int CA 1, ... , Int CA N, Root CA].
+ * @param {String|Array} ca [List] of CA certificates
  * @param {Function} callback Callback function with an error object and a boolean valid
  */
 function verifySigningChain (certificate, ca, callback) {
@@ -943,7 +945,7 @@ function verifySigningChain (certificate, ca, callback) {
     ca = undefined
   }
   if (!Array.isArray(certificate)) {
-    certificate = [certificate]
+    certificate = readFromString(certificate, CERT_START, CERT_END)
   }
   if (!Array.isArray(ca) && ca !== undefined) {
     if (ca !== '') {
@@ -951,31 +953,33 @@ function verifySigningChain (certificate, ca, callback) {
     }
   }
 
-  var files = []
-
-  if (ca !== undefined) {
-    // ca certificates
-    files.push(ca.join('\n'))
-  }
-  // certificate incl. intermediate certificates
-  files.push(certificate.join('\n'))
-
   var params = ['verify']
+  var files = []
 
   if (ca !== undefined) {
     // ca certificates
     params.push('-CAfile')
     params.push('--TMPFILE--')
+    files.push(ca.join('\n'))
   }
-  // certificate incl. intermediate certificates
+  // extracting the very first - leaf - cert in chain
+  var leaf = certificate.shift()
+
+  if (certificate.length > 0) {
+    params.push('-untrusted')
+    params.push('--TMPFILE--')
+    files.push(certificate.join('\n'))
+  }
+
   params.push('--TMPFILE--')
+  files.push(leaf)
 
   openssl.spawnWrapper(params, files, function (err, code, stdout, stderr) {
     if (err) {
       return callback(err)
     }
 
-    callback(null, stdout.trim().slice(-4) === ': OK')
+    callback(null, stdout.trim().slice(-2) === 'OK')
   })
 }
 

--- a/test/pem.spec.js
+++ b/test/pem.spec.js
@@ -714,6 +714,11 @@ describe('General Tests', function () {
           commonName: 'Intermediate CA Certificate',
           serviceKey: ca.serviceKey,
           serviceCertificate: ca.certificate,
+          config:
+              `
+              [v3_req]
+              basicConstraints = critical,CA:TRUE
+              `,
           serial: Date.now()
         }, function (error, intermediate) {
           hlp.checkError(error)
@@ -723,6 +728,11 @@ describe('General Tests', function () {
           pem.createCertificate({
             serviceKey: intermediate.clientKey,
             serviceCertificate: intermediate.certificate,
+            config:
+                `
+                [v3_req]
+                basicConstraints = critical,CA:TRUE
+                `,
             serial: Date.now()
             // days: 1024
           }, function (error, cert) {
@@ -731,7 +741,7 @@ describe('General Tests', function () {
             hlp.checkTmpEmpty()
 
             // chain check ok
-            pem.verifySigningChain([intermediate.certificate, cert.certificate], [
+            pem.verifySigningChain([cert.certificate, intermediate.certificate, ca.certificate], [
               ca.certificate, intermediate.certificate
             ], function (error, valid) {
               hlp.checkError(error)


### PR DESCRIPTION
This PR takes on the raised issue https://github.com/Dexus/pem/issues/303.

Basically, there were 3 problems:
- An entire certificate chain had been supplied to the `openssl verify` making `openssl` to silently read just the first one of the chain. Read why is that [here](https://stackoverflow.com/a/44377854/931559)
- The corresponding `-untrusted` param of `openssl verify` was never used, therefore the trust chain was never passed for verification.
- Looking at unit tests, the correct certificate order had been reversed. It should've been `leaf` -> `int ca` -> `root ca`, while in reality it was backwards. Also, the CA certificates were missing quite a critical part: the `CA:TRUE` attribute. 

So `verifySigningChain` was never working correctly in the general case. The simplest forms like `Root CA -> Leaf` or `Root CA -> Int CA -> Leaf` might be verified correctly, but anything more complicated than that - won't.  
 