### PR TITLE
Fix for openssl 3.x

### DIFF
--- a/lib/pem.js
+++ b/lib/pem.js
@@ -74,7 +74,7 @@ function createPrivateKey (keyBitsize, options, callback) {
 
   params.push(keyBitsize)
 
-  openssl.exec(params, 'RSA PRIVATE KEY', function (sslErr, key) {
+  openssl.exec(params, 'PRIVATE KEY', function (sslErr, key) {
     function done (err) {
       if (err) {
         return callback(err)


### PR DESCRIPTION
In `openssl` 3.x you can see the output of:
```
> openssl genrsa 2048
----BEGIN PRIVATE KEY----
....
----END PRIVATE KEY----
```

This causes an error in this lib since we are assuming the string `RSA PRIVATE KEY` in the output, and this result in the following error for users:
```
(node:16227) UnhandledPromiseRejectionWarning: Error: RSA PRIVATE KEY not found from openssl output: ---stdout--- ----BEGIN PRIVATE KEY----
...
----END PRIVATE KEY----
```

This PR updates the string we are comparing against. 