### PR TITLE
continue to use pkcs1 rsakey with openssl v3.x

### DIFF
--- a/lib/pem.js
+++ b/lib/pem.js
@@ -67,6 +67,11 @@ function createPrivateKey(keyBitsize, options, callback) {
   keyBitsize = Number(keyBitsize) || 2048
 
   var params = ['genrsa']
+
+  if (openssl.get('VendorVersionMajor') >= 3) {
+    params.push('-traditional')
+  }
+
   var delTempPWFiles = []
 
   if (options && options.cipher && (Number(helper.ciphers.indexOf(options.cipher)) !== -1) && options.password) {


### PR DESCRIPTION
openssl v3.x creates pkcs8 rsa key instead of pkcs1, and that makes pem lib not work properly.