### PR TITLE
use DEBUG flag instead of CI

### DIFF
--- a/lib/debug.js
+++ b/lib/debug.js
@@ -1,5 +1,5 @@
 function debug (title, content) {
-  if (process.env.CI === 'true') {
+  if (process.env.DEBUG === 'true') {
     console.log(`::group::${title}`)
     console.log(JSON.stringify(content, null, 3))
     console.log('::endgroup::')


### PR DESCRIPTION
CI is set to true in CI/CD tools such as Bitbucket pipelines. That results in excessive debug log if pem library is used in scripts that run in CI/CD of other projects, e.g. when pem library is used in tests that are running in a Bitbucket pipeline.
It would be therefore better to use a different flag than CI to control when debug logs are produced. This PR suggests DEBUG flag.