### PR TITLE
Fixes #123 potential TypeError in checkCertificate when stderr is undefined 

### DIFF
--- a/lib/pem.js
+++ b/lib/pem.js
@@ -997,13 +997,13 @@ function checkCertificate(certificate, passphrase, callback) {
           break
       }
       if (!result) {
+        if (err && err.toString().trim() !== 'verify OK') {
+          return callback(err)
+        }
         if (openssl.get('Vendor') === "OPENSSL" && openssl.get('VendorVersionMajor') >= 3) {
           if (!(stderr && stderr.toString().trim().endsWith('verify OK'))) {
             return callback(new Error(stderr.toString()))
           }
-        }
-        if (err && err.toString().trim() !== 'verify OK') {
-          return callback(err)
         }
       }
       callback(null, result)


### PR DESCRIPTION
## Problem

When validating an invalid certificate using `checkCertificate`, a runtime error can occur:


This happens because the implementation tries to call `.toString()` on `stderr`, which can be `undefined` in some cases.

#407 